### PR TITLE
Add greenlet to requirements to stop errors

### DIFF
--- a/core_backend/requirements.txt
+++ b/core_backend/requirements.txt
@@ -6,4 +6,4 @@ psycopg2==2.9.7
 asyncpg==0.28.0
 qdrant-client==1.5.4
 litellm==0.1.784
-greenlet==3.0.0
+sqlalchemy[asyncio]


### PR DESCRIPTION
Adding greenlet to the requirements file. The core app does not work for me otherwise.