### PR TITLE
[HOTFIX] Fixed missing libraries for mkdocs deployment

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,5 +1,6 @@
 name: Deploy Docs
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: "3.10"
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
       - uses: actions/cache@v3
         with:
@@ -20,5 +20,7 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install mkdocs-material pymdown-extensions
+      - run: pip install mkdocs-material==9.4.5 \
+          pymdown-extensions==10.3 \
+          mkdocs-glightbox==0.3.4
       - run: mkdocs gh-deploy --force

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,5 @@ pytest==7.4.2
 httpx==0.25.0
 trio==0.22.2
 mkdocs-material==9.4.5
+pymdown-extensions==10.3
 mkdocs-glightbox==0.3.4


### PR DESCRIPTION
Some libraries were missing that were probably causing gh-pages deployment to fail. 
This adds them back in.