### PR TITLE
Correct "main" to be the only docs deploy hook

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - hotfix_docs
+      - main
 permissions:
   contents: write
 jobs:


### PR DESCRIPTION
Add main as the docs deploy hook