### PR TITLE
Add new init bash file for local deployment testing

### DIFF
--- a/deployment/init-dummy-cert.sh
+++ b/deployment/init-dummy-cert.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -o allexport
+source .env.nginx
+set +o allexport
+
+# Check that docker compose command is available
+if ! [ -x "$(command -v docker)" ]; then
+  echo 'Error: docker is not installed.' >&2
+  exit 1
+fi
+
+if ! docker compose version >/dev/null 2>&1; then
+  echo 'Error: docker compose is not available.' >&2
+  exit 1
+fi
+
+domains=("$DOMAIN")
+rsa_key_size=4096
+data_path="./data/certbot"
+
+if [ -d "$data_path/conf/live/$domains" ]; then
+  read -p "Existing data found for $domains. Continue and replace existing certificate? (y/N) " decision
+  if [ "$decision" != "Y" ] && [ "$decision" != "y" ]; then
+    exit
+  fi
+fi
+
+
+if [ ! -e "$data_path/conf/options-ssl-nginx.conf" ] || [ ! -e "$data_path/conf/ssl-dhparams.pem" ]; then
+  echo "### Downloading recommended TLS parameters ..."
+  mkdir -p "$data_path/conf"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf > "$data_path/conf/options-ssl-nginx.conf"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot/certbot/ssl-dhparams.pem > "$data_path/conf/ssl-dhparams.pem"
+  echo
+fi
+
+echo "### Creating dummy certificate for $domains ..."
+path="/etc/letsencrypt/live/$domains"
+mkdir -p "$data_path/conf/live/$domains"
+docker compose run --rm --entrypoint "\
+  openssl req -x509 -nodes -newkey rsa:$rsa_key_size -days 1\
+    -keyout '$path/privkey.pem' \
+    -out '$path/fullchain.pem' \
+    -subj '/CN=localhost'" certbot

--- a/deployment/init-letsencrypt.sh
+++ b/deployment/init-letsencrypt.sh
@@ -20,7 +20,7 @@ data_path="./data/certbot"
 email="$MAIL" # Adding a valid address is strongly recommended
 staging=0 # Set to 1 if you're testing your setup to avoid hitting request limits
 
-if [ -d "$data_path" ]; then
+if [ -d "$data_path/conf/live/$domains" ]; then
   read -p "Existing data found for $domains. Continue and replace existing certificate? (y/N) " decision
   if [ "$decision" != "Y" ] && [ "$decision" != "y" ]; then
     exit

--- a/deployment/template.env
+++ b/deployment/template.env
@@ -3,19 +3,19 @@
 # NOTE: ALL VARIABLES MUST BE SET. IF NOT SET, PLEASE COMMENT IT OUT.
 # IF COMMENTED OUT, DEFAULT VALUES WILL BE USED FROM `core_backend/app/config/app_config.py
 
-POSTGRES_PASSWORD=
-OPENAI_API_KEY=
+# POSTGRES_PASSWORD=
+# OPENAI_API_KEY=
 
 # WARNING! Make sure you change thesd to some other string
 QUESTION_ANSWER_SECRET="idi-prod-qa-secret"
 JWT_SECRET="idi-prod-jwt-secret"
 
 # Set variables for deployment
-POSTGRES_HOST=
-DOMAIN=
+# POSTGRES_HOST=
+# DOMAIN=
 
 # If not set, it will use `http://localhost:8000`
-NEXT_PUBLIC_BACKEND_URL=
+# NEXT_PUBLIC_BACKEND_URL=
 
 # if using a nginx reverse proxy, set path here
 BACKEND_ROOT_PATH="/api"
@@ -27,10 +27,10 @@ CONTENT_READONLY_PASSWORD="readonly-prod"
 
 # Whatsapp Verification token
 # This is used to verify that the request is coming from Whatsapp
-WHATSAPP_VERIFY_TOKEN=
+# WHATSAPP_VERIFY_TOKEN=
 
 # Whatsapp API TOKEN
-WHATSAPP_TOKEN=
+# WHATSAPP_TOKEN=
 
 # Temporary folder for prometheus gunicorn multiprocess
 PROMETHEUS_MULTIPROC_DIR=/tmp


### PR DESCRIPTION
Reviewer: @sidravi1 

Estimate: 20mins

----

# Add new init bash file for local deployment testing

## Ticket

- not a ticket, but was a bug/blocker for local development

## Description, Motivation and Context

### Goal

Allow us to run the deployment script on localhost so we can test nginx.

### Changes

- added new init file that is similar to the letsencrypt one but only makes a dummy certificate. This certificate then allows us to load nginx and test the configuration.
- Also fixed the filepath that was being checked for duplicate certificates to reflect the correct path instead of the parent folder (which always exists, hence always getting a popup).
- added info to this [confluence page](https://idinsight.atlassian.net/wiki/spaces/PD/pages/2335048008/Local+NGINX+Deployment)

## How Has This Been Tested?

- Instead of running `./init-letsencrypt.sh`, run `./init-dummy-cert.sh` while following the deployment docs.
- Check that the admin app (on `localhost`) and the backend (on `localhost/api/docs`) work as expected.

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [-] I have updated the automated tests (if applicable)
- [x] I have written [good commit messages][1]
- [-] I have updated the README file (if applicable)
- [x] I have updated affected documentation (if applicable)

[1]: http://chris.beams.io/posts/git-commit/
