### PR TITLE
Increase the number of content list return

### DIFF
--- a/core_backend/app/routers/manage_content.py
+++ b/core_backend/app/routers/manage_content.py
@@ -96,7 +96,7 @@ async def retrieve_content(
         AuthenticatedUser, Depends(get_current_readonly_user)
     ],
     skip: int = 0,
-    limit: int = 10,
+    limit: int = 50,
     qdrant_client: QdrantClient = Depends(get_qdrant_client),
 ) -> List[ContentRetrieve]:
     """


### PR DESCRIPTION
# HotFix

Increase the number of content returned by the content list endpoint to a default of 50 for now