### PR TITLE
HOTFIX: add "content_response" content back into LLM call response

### DIFF
--- a/core_backend/app/routers/question_answer.py
+++ b/core_backend/app/routers/question_answer.py
@@ -80,6 +80,7 @@ async def llm_response(
     content_response = get_similar_content(
         user_query_refined, qdrant_client, int(QDRANT_N_TOP_SIMILAR)
     )
+    response.content_response = content_response
     response.llm_response = get_llm_rag_answer(
         user_query_refined.query_text, content_response[0].response_text
     )

--- a/core_backend/tests/api/test_question_answer.py
+++ b/core_backend/tests/api/test_question_answer.py
@@ -119,3 +119,7 @@ class TestLLMSearch:
         if expected_status_code == 200:
             llm_response = response.json()["llm_response"]
             assert len(llm_response) != 0
+
+        if expected_status_code == 200:
+            content_response = response.json()["content_response"]
+            assert len(content_response) != 0


### PR DESCRIPTION
Reviewer: @suzinyou 

Estimate: 10mins

----

# add "content_response" field back into LLM call response

## Description, Motivation and Context

Since Sid's revamp of the `llm-response` endpoint, it no longer returns the FAQs it used as a source. This just adds that back in. This is needed if we want to respond

## How Has This Been Tested?

- Run the app, add some content, test the llm endpoint.

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [-] I have updated the automated tests (if applicable)
- [x] I have written [good commit messages][1]
- [-] I have updated the README file (if applicable)
- [-] I have updated affected documentation (if applicable)

[1]: http://chris.beams.io/posts/git-commit/
