### PR TITLE
Refactor rails to use decorators

### DIFF
--- a/core_backend/app/configs/llm_prompts.py
+++ b/core_backend/app/configs/llm_prompts.py
@@ -5,7 +5,7 @@ from enum import Enum
 # ---- Safety bot
 
 
-class SafetyClassification(Enum):
+class SafetyClassification(str, Enum):
     """
     Safety classification of the user's input.
     """
@@ -56,7 +56,7 @@ class SafetyClassification(Enum):
 # ----  Language identification bot
 
 
-class IdentifiedLanguage(Enum):
+class IdentifiedLanguage(str, Enum):
     """
     Identified language of the user's input.
     """
@@ -65,6 +65,7 @@ class IdentifiedLanguage(Enum):
     XHOSA = "XHOSA"
     ZULU = "ZULU"
     AFRIKAANS = "AFRIKAANS"
+    HINDI = "HINDI"
     UNKNOWN = "UNKNOWN"
 
     @classmethod
@@ -89,21 +90,33 @@ class IdentifiedLanguage(Enum):
         [{",".join(cls._member_names_)}]
         """
 
+    @classmethod
+    def get_supported_languages(cls) -> list[str]:
+        """
+        Returns a list of supported languages.
+        """
+        return [lang for lang in cls._member_names_ if lang != "UNKNOWN"]
+
 
 # ----  Translation bot
-
-TRANSLATE_INPUT = """
+TRANSLATE_FAILED_MESSAGE = "ERROR: CAN'T TRANSLATE"
+TRANSLATE_INPUT = f"""
     You are a high-performing translation bot for low-resourced African languages.
-    You support a maternal and child health chatbot.
+    You support a question-answering chatbot.
+    If you are unable to translate the user's input,
+    respond with {TRANSLATE_FAILED_MESSAGE}
     Translate the user's input to English from """
 
 # ---- Paraphrase question
-
-PARAPHRASE_INPUT = """
+PARAPHRASE_FAILED_MESSAGE = "ERROR: CAN'T PARAPHRASE"
+PARAPHRASE_INPUT = f"""
     You are a high-performing paraphrase bot.
-    You support a maternal and child health chatbot.
-    The user has asked a health question in English, paraphrase it to focus on
-    the health question. Be succinct and do not include any unnecessary information."""
+    You support a question-answering service.
+    The user has asked a question in English, paraphrase it to focus on
+    the question. Be succinct and do not include any unnecessary information.
+    Ignore any redacted and offensive words.
+    If no paraphrase is possible, respond with {PARAPHRASE_FAILED_MESSAGE}
+    """
 
 # ----  Question answering bot
 

--- a/core_backend/app/db/vector_db.py
+++ b/core_backend/app/db/vector_db.py
@@ -56,9 +56,9 @@ def get_similar_content(
     Get the most similar points in the vector db
     """
 
-    question_embedding = (
-        embedding(EMBEDDING_MODEL, question.query_text).data[0].embedding
-    )
+    question_embedding = embedding(EMBEDDING_MODEL, question.query_text).data[0][
+        "embedding"
+    ]
 
     search_result = qdrant_client.search(
         collection_name=QDRANT_COLLECTION_NAME,

--- a/core_backend/app/llm_call/parse_input.py
+++ b/core_backend/app/llm_call/parse_input.py
@@ -19,6 +19,11 @@ from .utils import _ask_llm
 
 logger = setup_logger("INPUT RAILS")
 
+STANDARD_FAILURE_MESSAGE = (
+    "Sorry, I am unable to understand your question. "
+    "Please rephrase your question and try again."
+)
+
 
 def classify_safety(func: Callable) -> Callable:
     """
@@ -54,10 +59,7 @@ def _classify_safety(
             _ask_llm(question.query_text, SafetyClassification.get_prompt()),
         )
         if safety_classification != SafetyClassification.SAFE:
-            response.llm_response = (
-                "Sorry, we are unable to answer your question."
-                "Please rephrase your question and try again."
-            )
+            response.llm_response = STANDARD_FAILURE_MESSAGE
             response.state = ResultState.ERROR
         response.debug_info["safety_classification"] = safety_classification.value
 
@@ -153,9 +155,8 @@ def _translate_question(
         supported_languages = ", ".join(IdentifiedLanguage.get_supported_languages())
 
         response.llm_response = (
-            "Sorry, we are unable to understand your question. "
-            f"Only the following languages are supported: {supported_languages}. "
-            "Please rephrase your question and try again."
+            STANDARD_FAILURE_MESSAGE
+            + f"Only the following languages are supported: {supported_languages}. "
         )
 
         response.state = ResultState.ERROR
@@ -171,10 +172,7 @@ def _translate_question(
             question.query_text = translation_response
             response.debug_info["translated_question"] = translation_response
         else:
-            response.llm_response = (
-                "Sorry, we are unable to understand your question. "
-                "Please rephrase your question and try again."
-            )
+            response.llm_response = STANDARD_FAILURE_MESSAGE
             response.state = ResultState.ERROR
             logger.info("TRANSLATION FAILED on question: " + question.query_text)
 

--- a/core_backend/app/llm_call/parse_input.py
+++ b/core_backend/app/llm_call/parse_input.py
@@ -2,75 +2,196 @@
 These are functions that can be used to parse the input questions.
 """
 
+from functools import wraps
+from typing import Any, Callable, Tuple
+
 from ..configs.llm_prompts import (
     PARAPHRASE_INPUT,
     TRANSLATE_INPUT,
     IdentifiedLanguage,
     SafetyClassification,
 )
-from ..schemas import UserQueryRefined
+from ..schemas import ResultState, UserQueryRefined, UserQueryResponse
 from .utils import _ask_llm
 
 
-def classify_safety(query_text: str) -> SafetyClassification:
+def classify_safety(func: Callable) -> Callable:
+    """
+    Decorator to classify the safety of the question.
+    """
+
+    @wraps(func)
+    async def wrapper(
+        question: UserQueryRefined,
+        response: UserQueryResponse,
+        *args: Any,
+        **kwargs: Any,
+    ) -> UserQueryResponse:
+        """
+        Wrapper function to classify the safety of the question.
+        """
+        question, response = _classify_safety(question, response)
+        response = await func(question, response, *args, **kwargs)
+        return response
+
+    return wrapper
+
+
+def _classify_safety(
+    question: UserQueryRefined, response: UserQueryResponse
+) -> Tuple[UserQueryRefined, UserQueryResponse]:
     """
     Classifies the safety of the question.
     """
-    return getattr(
-        SafetyClassification,
-        _ask_llm(query_text, SafetyClassification.get_prompt()),
-    )
+    if response.state != ResultState.ERROR:
+        safety_classification = getattr(
+            SafetyClassification,
+            _ask_llm(question.query_text, SafetyClassification.get_prompt()),
+        )
+        if safety_classification != SafetyClassification.SAFE:
+            response.llm_response = (
+                "Sorry, we are unable to answer your question."
+                "Please rephrase your question and try again."
+            )
+            response.state = ResultState.ERROR
+        response.debug_info["safety_classification"] = safety_classification.value
+
+    return question, response
 
 
-def input_is_safe(question: UserQueryRefined) -> bool:
+def identify_language(func: Callable) -> Callable:
     """
-    Checks for prompt injection and inappropriate language in the question.
+    Decorator to identify the language of the question.
     """
-    if classify_safety(question.query_text) == SafetyClassification.SAFE:
-        return True
-    else:
-        return False
+
+    @wraps(func)
+    async def wrapper(
+        question: UserQueryRefined,
+        response: UserQueryResponse,
+        *args: Any,
+        **kwargs: Any,
+    ) -> UserQueryResponse:
+        """
+        Wrapper function to identify the language of the question.
+        """
+        question, response = _identify_language(question, response)
+        response = await func(question, response, *args, **kwargs)
+        return response
+
+    return wrapper
 
 
-def identify_language(question: UserQueryRefined) -> UserQueryRefined:
+def _identify_language(
+    question: UserQueryRefined, response: UserQueryResponse
+) -> Tuple[UserQueryRefined, UserQueryResponse]:
     """
     Identifies the language of the question.
     """
+    if response.state != ResultState.ERROR:
+        question.original_language = getattr(
+            IdentifiedLanguage,
+            _ask_llm(question.query_text, IdentifiedLanguage.get_prompt()),
+        )
+        if question.original_language is not None:
+            response.debug_info["original_language"] = question.original_language.value
 
-    question.original_language = getattr(
-        IdentifiedLanguage,
-        _ask_llm(question.query_text, IdentifiedLanguage.get_prompt()),
-    )
-
-    return question
+    return question, response
 
 
-def translate_question(question: UserQueryRefined) -> UserQueryRefined:
+def translate_question(func: Callable) -> Callable:
+    """
+    Decorator to translate the question.
+    """
+
+    @wraps(func)
+    async def wrapper(
+        question: UserQueryRefined,
+        response: UserQueryResponse,
+        *args: Any,
+        **kwargs: Any,
+    ) -> UserQueryResponse:
+        """
+        Wrapper function to translate the question.
+        """
+        question, response = _identify_language(question, response)
+        question, response = _translate_question(question, response)
+        response = await func(question, response, *args, **kwargs)
+        response.debug_info["translated_question"] = question.query_text
+
+        return response
+
+    return wrapper
+
+
+def _translate_question(
+    question: UserQueryRefined, response: UserQueryResponse
+) -> Tuple[UserQueryRefined, UserQueryResponse]:
     """
     Translates the question to English.
     """
 
     if (
-        question.original_language
-        in [
-            IdentifiedLanguage.ENGLISH,
-            IdentifiedLanguage.UNKNOWN,
-        ]
-        or question.original_language is None
+        question.original_language == IdentifiedLanguage.ENGLISH
+        or response.state == ResultState.ERROR
     ):
-        return question
+        return question, response
+
+    if question.original_language is None:
+        response.state = ResultState.ERROR
+        raise ValueError(
+            (
+                "Language hasn't been identified. "
+                "Identify language before running translation"
+            )
+        )
+
+    if question.original_language == IdentifiedLanguage.UNKNOWN:
+        response.llm_response = (
+            "Sorry, we are unable to understand your question. "
+            "Please rephrase your question and try again."
+        )
+        response.state = ResultState.ERROR
     else:
         question.query_text = _ask_llm(
             question.query_text, TRANSLATE_INPUT + question.original_language.value
         )
-        return question
+
+    return question, response
 
 
-def paraphrase_question(question: UserQueryRefined) -> UserQueryRefined:
+def paraphrase_question(func: Callable) -> Callable:
+    """
+    Decorator to paraphrase the question.
+    """
+
+    @wraps(func)
+    async def wrapper(
+        question: UserQueryRefined,
+        response: UserQueryResponse,
+        *args: Any,
+        **kwargs: Any,
+    ) -> UserQueryResponse:
+        """
+        Wrapper function to paraphrase the question.
+        """
+        question, response = _paraphrase_question(question, response)
+        response = await func(question, response, *args, **kwargs)
+
+        return response
+
+    return wrapper
+
+
+def _paraphrase_question(
+    question: UserQueryRefined, response: UserQueryResponse
+) -> Tuple[UserQueryRefined, UserQueryResponse]:
     """
     Paraphrases the question.
     """
 
+    if response.state == ResultState.ERROR:
+        return question, response
+
     question.query_text = _ask_llm(question.query_text, PARAPHRASE_INPUT)
 
-    return question
+    return question, response

--- a/core_backend/app/llm_call/parse_input.py
+++ b/core_backend/app/llm_call/parse_input.py
@@ -156,7 +156,7 @@ def _translate_question(
 
         response.llm_response = (
             STANDARD_FAILURE_MESSAGE
-            + f"Only the following languages are supported: {supported_languages}. "
+            + f" Only the following languages are supported: {supported_languages}. "
         )
 
         response.state = ResultState.ERROR

--- a/core_backend/app/routers/manage_content.py
+++ b/core_backend/app/routers/manage_content.py
@@ -182,9 +182,9 @@ def _upsert_content_to_qdrant(
 ) -> ContentRetrieve:
     """Add content to qdrant collection"""
 
-    content_embedding = (
-        embedding(EMBEDDING_MODEL, content.content_text).data[0].embedding
-    )
+    content_embedding = embedding(EMBEDDING_MODEL, content.content_text).data[0][
+        "embedding"
+    ]
 
     qdrant_client.upsert(
         collection_name=QDRANT_COLLECTION_NAME,

--- a/core_backend/app/routers/question_answer.py
+++ b/core_backend/app/routers/question_answer.py
@@ -58,9 +58,9 @@ async def llm_response(
 
 
 @classify_safety
-@paraphrase_question
 @translate_question
 @identify_language
+@paraphrase_question
 async def get_llm_answer(
     user_query_refined: UserQueryRefined,
     response: UserQueryResponse,
@@ -99,7 +99,7 @@ async def get_user_query_and_response(
     response = UserQueryResponse(
         query_id=user_query_db.query_id,
         content_response=None,
-        llm_response="Sorry, we cannot do that.",
+        llm_response=None,
         feedback_secret_key=feedback_secret_key,
     )
 
@@ -130,8 +130,8 @@ async def embeddings_search(
     return response
 
 
-@paraphrase_question
 @translate_question
+@paraphrase_question
 async def get_semantic_matches(
     user_query_refined: UserQueryRefined,
     response: UserQueryResponse,

--- a/core_backend/app/routers/question_answer.py
+++ b/core_backend/app/routers/question_answer.py
@@ -1,3 +1,4 @@
+from typing import Tuple
 from uuid import uuid4
 
 from fastapi import APIRouter, Depends
@@ -7,8 +8,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth import auth_bearer_token
 from ..configs.app_config import QDRANT_N_TOP_SIMILAR
-from ..configs.llm_prompts import IdentifiedLanguage
 from ..db.db_models import (
+    UserQueryDB,
     check_secret_key_match,
     save_feedback_to_db,
     save_query_response_to_db,
@@ -18,8 +19,8 @@ from ..db.engine import get_async_session
 from ..db.vector_db import get_qdrant_client, get_similar_content
 from ..llm_call.llm_rag import get_llm_rag_answer
 from ..llm_call.parse_input import (
+    classify_safety,
     identify_language,
-    input_is_safe,
     paraphrase_question,
     translate_question,
 )
@@ -43,40 +44,30 @@ async def llm_response(
     LLM response creates a custom response to the question using LLM chat and the
     most similar embeddings to the user query in the vector db.
     """
+    (
+        user_query_db,
+        user_query_refined,
+        response,
+    ) = await get_user_query_and_response(user_query, asession)
 
-    feedback_secret_key = generate_secret_key()
+    response = await get_llm_answer(user_query_refined, response, qdrant_client)
+    await save_query_response_to_db(asession, user_query_db, response)
 
-    user_query_db = await save_user_query_to_db(
-        asession, feedback_secret_key, user_query
-    )
+    return response
 
-    user_query_refined = UserQueryRefined(
-        **user_query.model_dump(), query_text_original=user_query.query_text
-    )
 
-    response = UserQueryResponse(
-        query_id=user_query_db.query_id,
-        content_response=None,
-        llm_response="Sorry, we cannot do that.",
-        feedback_secret_key=feedback_secret_key,
-    )
-
-    # -- pre-process input
-    if not input_is_safe(user_query_refined):
-        return response
-
-    user_query_refined = identify_language(user_query_refined)
-    if user_query_refined.original_language == IdentifiedLanguage.UNKNOWN:
-        response.llm_response = (
-            "Sorry, we are unable to understand your question. "
-            "Please rephrase your question and try again."
-        )
-        return response
-    if user_query_refined.original_language != IdentifiedLanguage.ENGLISH:
-        user_query_refined = translate_question(user_query_refined)
-    user_query_refined = paraphrase_question(user_query_refined)
-
-    # -- RAG call
+@classify_safety
+@paraphrase_question
+@translate_question
+@identify_language
+async def get_llm_answer(
+    user_query_refined: UserQueryRefined,
+    response: UserQueryResponse,
+    qdrant_client: QdrantClient,
+) -> UserQueryResponse:
+    """
+    Get similar content and construct the LLM answer for the user query
+    """
     content_response = get_similar_content(
         user_query_refined, qdrant_client, int(QDRANT_N_TOP_SIMILAR)
     )
@@ -84,14 +75,32 @@ async def llm_response(
     response.llm_response = get_llm_rag_answer(
         user_query_refined.query_text, content_response[0].response_text
     )
-    response.debug_info = {
-        "paraphrase": user_query_refined.query_text,
-        "original_language": user_query_refined.original_language,
-    }
-
-    await save_query_response_to_db(asession, user_query_db, response)
 
     return response
+
+
+async def get_user_query_and_response(
+    user_query: UserQueryBase, asession: AsyncSession
+) -> Tuple[UserQueryDB, UserQueryRefined, UserQueryResponse]:
+    """
+    Get the user query from the request and save it to the db.
+    Construct an object for user query and a default response object.
+    """
+    feedback_secret_key = generate_secret_key()
+    user_query_db = await save_user_query_to_db(
+        asession, feedback_secret_key, user_query
+    )
+    user_query_refined = UserQueryRefined(
+        **user_query.model_dump(), query_text_original=user_query.query_text
+    )
+    response = UserQueryResponse(
+        query_id=user_query_db.query_id,
+        content_response=None,
+        llm_response="Sorry, we cannot do that.",
+        feedback_secret_key=feedback_secret_key,
+    )
+
+    return user_query_db, user_query_refined, response
 
 
 @router.post("/embeddings-search")
@@ -104,42 +113,35 @@ async def embeddings_search(
     Embeddings search finds the most similar embeddings to the user query
     from the vector db.
     """
+    (
+        user_query_db,
+        user_query_refined,
+        response,
+    ) = await get_user_query_and_response(user_query, asession)
 
-    feedback_secret_key = generate_secret_key()
-
-    user_query_db = await save_user_query_to_db(
-        asession, feedback_secret_key, user_query
+    response = await get_semantic_matches(
+        user_query_refined, response, qdrant_client, int(QDRANT_N_TOP_SIMILAR)
     )
-
-    user_query_refined = UserQueryRefined(
-        **user_query.model_dump(), query_text_original=user_query.query_text
-    )
-    user_query_refined = identify_language(user_query_refined)
-    if user_query_refined.original_language not in [
-        IdentifiedLanguage.UNKNOWN,
-        IdentifiedLanguage.ENGLISH,
-    ]:
-        user_query_refined = translate_question(user_query_refined)
-    user_query_refined = paraphrase_question(user_query_refined)
-
-    content_response = get_similar_content(
-        user_query, qdrant_client, int(QDRANT_N_TOP_SIMILAR)
-    )
-
-    response = UserQueryResponse(
-        query_id=user_query_db.query_id,
-        content_response=content_response,
-        llm_response=None,
-        feedback_secret_key=feedback_secret_key,
-    )
-    response.debug_info = {
-        "paraphrase": user_query_refined.query_text,
-        "original_language": user_query_refined.original_language,
-    }
-
     await save_query_response_to_db(asession, user_query_db, response)
 
-    # respond to user
+    return response
+
+
+@paraphrase_question
+@translate_question
+async def get_semantic_matches(
+    user_query_refined: UserQueryRefined,
+    response: UserQueryResponse,
+    qdrant_client: QdrantClient,
+    n_top_similar: int,
+) -> UserQueryResponse:
+    """
+    Get similar contents from vector db
+    """
+    content_response = get_similar_content(
+        user_query_refined, qdrant_client, n_top_similar
+    )
+    response.content_response = content_response
     return response
 
 

--- a/core_backend/app/routers/question_answer.py
+++ b/core_backend/app/routers/question_answer.py
@@ -26,6 +26,7 @@ from ..llm_call.parse_input import (
 )
 from ..schemas import (
     FeedbackBase,
+    ResultState,
     UserQueryBase,
     UserQueryRefined,
     UserQueryResponse,
@@ -68,6 +69,8 @@ async def get_llm_answer(
     """
     Get similar content and construct the LLM answer for the user query
     """
+    if response.state == ResultState.ERROR:
+        return response
     content_response = get_similar_content(
         user_query_refined, qdrant_client, int(QDRANT_N_TOP_SIMILAR)
     )
@@ -138,6 +141,8 @@ async def get_semantic_matches(
     """
     Get similar contents from vector db
     """
+    if response.state == ResultState.ERROR:
+        return response
     content_response = get_similar_content(
         user_query_refined, qdrant_client, n_top_similar
     )

--- a/core_backend/app/schemas.py
+++ b/core_backend/app/schemas.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import Enum
 from typing import Dict, Literal, Optional
 
 from pydantic import UUID4, BaseModel, ConfigDict
@@ -17,6 +18,16 @@ class UserQueryBase(BaseModel):
     query_metadata: dict = {}
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class ResultState(str, Enum):
+    """
+    Enum for Response state
+    """
+
+    FINAL = "final"
+    IN_PROGRESS = "in_progress"
+    ERROR = "error"
 
 
 class UserQueryRefined(UserQueryBase):
@@ -49,6 +60,7 @@ class UserQueryResponse(BaseModel):
     llm_response: Optional[str] = None
     feedback_secret_key: str
     debug_info: dict = {}
+    state: ResultState = ResultState.IN_PROGRESS
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/core_backend/requirements.txt
+++ b/core_backend/requirements.txt
@@ -5,7 +5,7 @@ alembic==1.12.0
 psycopg2==2.9.9
 asyncpg==0.28.0
 qdrant-client==1.5.4
-litellm==0.1.784
+litellm==1.16.3
 sqlalchemy[asyncio]==2.0.20
 python-multipart==0.0.6
 types-python-jose==3.3.4.8

--- a/core_backend/tests/api/conftest.py
+++ b/core_backend/tests/api/conftest.py
@@ -40,9 +40,9 @@ def faq_contents(client: TestClient) -> None:
     points = []
     for content in json_data:
         point_id = str(uuid.uuid4())
-        content_embedding = (
-            fake_embedding(EMBEDDING_MODEL, content["content_text"]).data[0].embedding
-        )
+        content_embedding = fake_embedding(
+            EMBEDDING_MODEL, content["content_text"]
+        ).data[0]["embedding"]
         metadata = content.get("content_metadata", {})
         payload = _create_payload_for_qdrant_upsert(content["content_text"], metadata)
         points.append(
@@ -98,8 +98,7 @@ def fake_embedding(*arg: str, **kwargs: str) -> EmbeddingData:
     """
 
     embedding_list = np.random.rand(int(QDRANT_VECTOR_SIZE)).astype(np.float32).tolist()
-    embedding = EmbeddingValues(embedding_list)
-    data_obj = EmbeddingData([embedding])
+    data_obj = EmbeddingData([{"embedding": embedding_list}])
 
     return data_obj
 

--- a/core_backend/tests/rails/test_language_indentification.py
+++ b/core_backend/tests/rails/test_language_indentification.py
@@ -4,8 +4,8 @@ import pytest
 import yaml
 
 from core_backend.app.configs.llm_prompts import IdentifiedLanguage
-from core_backend.app.llm_call.parse_input import identify_language
-from core_backend.app.schemas import UserQueryRefined
+from core_backend.app.llm_call.parse_input import _identify_language
+from core_backend.app.schemas import UserQueryRefined, UserQueryResponse
 
 pytestmark = pytest.mark.rails
 
@@ -34,8 +34,13 @@ def test_language_identification(
 ) -> None:
     """Test language identification"""
     question = UserQueryRefined(query_text=content, query_text_original=content)
+    response = UserQueryResponse(
+        query_id=1,
+        content_response=None,
+        llm_response="Dummy response",
+        feedback_secret_key="feedback-string",
+    )
     if language not in available_languages:
         language = "UNKNOWN"
-    identified_language = identify_language(question).original_language
-    assert identified_language is not None
-    assert identified_language.value == language
+    _, response = _identify_language(question, response)
+    assert response.debug_info["original_language"] == language

--- a/core_backend/tests/rails/test_safety.py
+++ b/core_backend/tests/rails/test_safety.py
@@ -1,7 +1,8 @@
 import pytest
 
 from core_backend.app.configs.llm_prompts import SafetyClassification
-from core_backend.app.llm_call.parse_input import classify_safety
+from core_backend.app.llm_call.parse_input import _classify_safety
+from core_backend.app.schemas import ResultState, UserQueryRefined, UserQueryResponse
 
 pytestmark = pytest.mark.rails
 
@@ -17,24 +18,59 @@ def read_test_data(file: str) -> list[str]:
         return f.read().splitlines()
 
 
+@pytest.fixture
+def response() -> UserQueryResponse:
+    """Returns a dummy response"""
+    return UserQueryResponse(
+        query_id=1,
+        content_response=None,
+        llm_response="Dummy response",
+        feedback_secret_key="feedback-string",
+    )
+
+
 @pytest.mark.parametrize("prompt_injection", read_test_data(PROMPT_INJECTION_FILE))
-def test_prompt_injection_found(prompt_injection: pytest.FixtureRequest) -> None:
+def test_prompt_injection_found(
+    prompt_injection: pytest.FixtureRequest, response: pytest.FixtureRequest
+) -> None:
     """Tests that prompt injection is found"""
-    assert classify_safety(prompt_injection) == SafetyClassification.PROMPT_INJECTION
+    question = UserQueryRefined(
+        query_text=prompt_injection, query_text_original=prompt_injection
+    )
+    _, response = _classify_safety(question, response)
+    assert response.state == ResultState.ERROR
+    assert (
+        response.debug_info["safety_classification"]
+        == SafetyClassification.PROMPT_INJECTION.value
+    )
 
 
 @pytest.mark.parametrize("safe_text", read_test_data(SAFE_MESSAGES_FILE))
-def test_safe_message(safe_text: pytest.FixtureRequest) -> None:
+def test_safe_message(
+    safe_text: pytest.FixtureRequest, response: pytest.FixtureRequest
+) -> None:
     """Tests that safe messages are classified as safe"""
-    assert classify_safety(safe_text) == SafetyClassification.SAFE
+    question = UserQueryRefined(query_text=safe_text, query_text_original=safe_text)
+    _, response = _classify_safety(question, response)
+    assert response.state != ResultState.ERROR
+    assert (
+        response.debug_info["safety_classification"] == SafetyClassification.SAFE.value
+    )
 
 
 @pytest.mark.parametrize(
     "inappropriate_text", read_test_data(INAPPROPRIATE_LANGUAGE_FILE)
 )
-def test_inappropriate_language(inappropriate_text: pytest.FixtureRequest) -> None:
+def test_inappropriate_language(
+    inappropriate_text: pytest.FixtureRequest, response: pytest.FixtureRequest
+) -> None:
     """Tests that inappropriate language is found"""
+    question = UserQueryRefined(
+        query_text=inappropriate_text, query_text_original=inappropriate_text
+    )
+    _, response = _classify_safety(question, response)
+    assert response.state == ResultState.ERROR
     assert (
-        classify_safety(inappropriate_text)
-        == SafetyClassification.INAPPROPRIATE_LANGUAGE
+        response.debug_info["safety_classification"]
+        == SafetyClassification.INAPPROPRIATE_LANGUAGE.value
     )


### PR DESCRIPTION
Reviewer: @suzinyou 

Estimate: 2 hrs

----

# Refactor rails

## Ticket

Fixes: [AAQ-258](https://idinsight.atlassian.net/browse/AAQ-258)

## Description, Motivation and Context

### Goal

Adding rail made the code very difficult to read.
It was going to get every more messy as we added alignment rails.

By setting it up as decorators, it cleans up the flow substantially and moves the complexity to the rails modules

## How Has This Been Tested?

Tests have been refactored as well and pass

You can test the rails tests using
```
cd core_backend
export OPENAI_API_KEY=<API_KEY>
python -m pytest -m rails
```

!!! Note: `test_llm_response_in_context.py` tests will fail right now

## Next steps

Add rails for LLM response alignment
Update docs

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have updated the automated tests (if applicable)
- [x] I have written [good commit messages]
- [x] I have updated the README file (if applicable)
- [ ] I have updated affected documentation (if applicable)



[AAQ-258]: https://idinsight.atlassian.net/browse/AAQ-258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ