### PR TITLE
AAQ-268: Fix close edit modal bug

### DIFF
--- a/admin_app/src/app/page.tsx
+++ b/admin_app/src/app/page.tsx
@@ -105,7 +105,7 @@ export default function Home() {
 
   // functions to edit and add content
   const editCard = (card: Content) => {
-    setCardToEdit(card);
+    setCardToEdit({ ...card });
     setShowEditModal(true);
   };
 


### PR DESCRIPTION
Reviewer: @suzinyou 

Estimate: 10 mins

----

# Fixed bug where on closing the card Edit Modal, unsaved changes are displayed on card

## Ticket

Fixes: [AAQ-268](https://idinsight.atlassian.net/browse/AAQ-268?atlOrigin=eyJpIjoiYjM2YWNhZmQzZWM0NGE1Nzk5Mzk4MTFlNzliYzY5OGYiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

## Description, Motivation and Context

See ticket for more details.
Or this Loom [video](https://www.loom.com/share/3ead247025c54be1b445fb05c8680393).

### Changes

See the one line changed.

Previously, when calling `setCardToEdit` we were not creating a copy of the card but sending the actual one being rendered. Now it creates a copy that is discarded.

### Why

Fix them bugs! 

## How Has This Been Tested?

From the front end
[Video](https://www.loom.com/share/7ec651d9726a4a42a964194718ae3963?sid=d5bd5604-6d82-4f62-a9bf-b73e31c1242c)

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have updated the automated tests (if applicable)
- [x] I have written [good commit messages][1]
- [x] I have updated the README file (if applicable)
- [x] I have updated affected documentation (if applicable)

[1]: http://chris.beams.io/posts/git-commit/


[AAQ-268]: https://idinsight.atlassian.net/browse/AAQ-268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ