### PR TITLE
AAQ-254: Added AlignScore 

### DIFF
--- a/.github/workflows/build-alignscore.yaml
+++ b/.github/workflows/build-alignscore.yaml
@@ -1,4 +1,4 @@
-name: Deploy on push to main
+name: Build AlignScore image
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/build-alignscore.yaml
+++ b/.github/workflows/build-alignscore.yaml
@@ -1,0 +1,47 @@
+name: Deploy on push to main
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "**"
+    paths:
+      - optional_components/alignScore/**
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read # This is required for actions/checkout
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    environment: dev
+    steps:
+      # Add a setup buildx step
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/github_actions_dev
+          role-session-name: github-actions
+          aws-region: us-east-1 # ${{ vars.AWS_REGION }}
+      - name: Login to Amazon ECR
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        env:
+          REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
+          REGISTRY_ALIAS: j3r7b4k0
+          REPOSITORY: alignscore-base
+          IMAGE_TAG: latest
+        with:
+          context: optional_components/alignScore/
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.REGISTRY_ALIAS }}/${{ env.REPOSITORY }}:${{ env.IMAGE_TAG }}

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -1,36 +1,42 @@
 name: Python Linting
-on: push
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "**"
+    paths:
+      - "**.py"
 
 jobs:
   python-lint-check:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v3
 
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
-        cache: 'pip'
-        cache-dependency-path: |
-          core_backend/requirements.txt
-          requirements-dev.txt
-    - run: |
-        python -m pip install --upgrade pip
-        pip install -r core_backend/requirements.txt
-        pip install -r requirements-dev.txt
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: |
+            core_backend/requirements.txt
+            requirements-dev.txt
+      - run: |
+          python -m pip install --upgrade pip
+          pip install -r core_backend/requirements.txt
+          pip install -r requirements-dev.txt
 
-    - name: Run MyPy
-      run: |
-        mypy core_backend/app
+      - name: Run MyPy
+        run: |
+          mypy core_backend/app
 
-    - name: Run ruff
-      run: |
-        ruff --exclude "core_backend/migrations" .
+      - name: Run ruff
+        run: |
+          ruff --exclude "core_backend/migrations" .
 
-    - name: Check code formatting with Black
-      run: |
-        cd core_backend
-        black --check .
+      - name: Check code formatting with Black
+        run: |
+          cd core_backend
+          black --check .

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,15 +1,16 @@
 name: Unit Tests
 on:
+  workflow_dispatch:
   push:
     branches:
       - "**"
-    paths-ignore:
-      - "**/*.md"
+    paths:
+      - "**.py"
 env:
   POSTGRES_PASSWORD: postgres-test-pw
   POSTGRES_USER: postgres-test-user
   POSTGRES_DB: postgres-test-db
-
+  ALIGN_SCORE_API: http://alignscore:5001/alignscore_base
 jobs:
   container-job:
     runs-on: ubuntu-20.04
@@ -32,6 +33,15 @@ jobs:
         image: qdrant/qdrant
         ports:
           - 6333:6333
+      alignscore:
+        image: public.ecr.aws/j3r7b4k0/alignscore-base:latest
+        ports:
+          - 5001:5001
+        options: >-
+          --health-cmd "curl -f http://localhost:5001/healthcheck"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - name: install dependencies
         run: apt-get update && apt-get install -y lsb-release && apt-get clean all
@@ -52,6 +62,7 @@ jobs:
           cd core_backend
           export POSTGRES_HOST=postgres POSTGRES_USER=$POSTGRES_USER \
             POSTGRES_PASSWORD=$POSTGRES_PASSWORD POSTGRES_DB=$POSTGRES_DB \
-            QDRANT_COLLECTION_NAME=test_collection QDRANT_HOST=qdrant
+            QDRANT_COLLECTION_NAME=test_collection QDRANT_HOST=qdrant \
+            ALIGN_SCORE_API=$ALIGN_SCORE_API
           python -m alembic upgrade head
           python -m pytest -m "not rails"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
     container: node:20.7-bullseye
     services:
       postgres:
-        image: postgres
+        image: postgres:16.1-alpine
         env:
           POSTGRES_PASSWORD: ${{ env.POSTGRES_PASSWORD }}
           POSTGRES_USER: ${{ env.POSTGRES_USER }}
@@ -30,7 +30,7 @@ jobs:
         ports:
           - 5432:5432
       qdrant:
-        image: qdrant/qdrant
+        image: qdrant/qdrant:v1.5.1
         ports:
           - 6333:6333
       alignscore:

--- a/core_backend/Makefile
+++ b/core_backend/Makefile
@@ -50,7 +50,7 @@ setup-test-relational-db:
 		-e POSTGRES_PASSWORD \
 		-e POSTGRES_USER \
 		-e POSTGRES_DB \
-		-d postgres
+		-d postgres:16.1-alpine
 	@set -a && source ./tests/api/test.env && set +a && \
 	python -m alembic upgrade head
 
@@ -59,14 +59,14 @@ setup-test-vector-db:
 	-@docker rm testvectordb
 	docker run --name testvectordb \
 		-p 6334:6333 \
-		-d qdrant/qdrant
+		-d qdrant/qdrant:v1.5.1
 
 setup-alignscore-container:
 	-@docker stop testalignscore
 	-@docker rm testalignscore
 	docker run --name testalignscore \
 		-p 5002:5001 \
-		-d alignscore-base
+		-d alignscore-base:latest
 	@sleep 10
 
 stop-alignscore-container:
@@ -107,7 +107,7 @@ setup-relational-db:
 	@docker run --name postgres-local \
      -e POSTGRES_PASSWORD=postgres \
      -p 5432:5432 \
-     -d postgres
+     -d postgres:16.1-alpine
 	python -m alembic upgrade head
 
 setup-vector-db:
@@ -115,7 +115,7 @@ setup-vector-db:
 	-@docker rm qdrant-local
 	docker run --name qdrant-local \
      -p 6333:6333 \
-     -d qdrant/qdrant
+	 -d qdrant/qdrant:v1.5.1
 
 stop-relational-db:
 	@docker stop postgres-local

--- a/core_backend/Makefile
+++ b/core_backend/Makefile
@@ -28,17 +28,16 @@ fresh-env :
 	fi
 
 # Running Tests
-tests: setup-test-relational-db setup-test-vector-db run-tests stop-test-relational-db stop-test-vector-db
-
+tests: setup-test-containers run-tests teardown-test-containers
 run-tests:
 	@set -a && source ./tests/api/test.env && set +a && \
 	python -m alembic upgrade head && \
 	python -m pytest -rPQ -m "not rails"
 
 # Test DBs
-setup-test-dbs: setup-test-relational-db setup-test-vector-db
+setup-test-containers: setup-test-relational-db setup-test-vector-db setup-alignscore-container
 
-teardown-test-dbs: stop-test-relational-db stop-test-vector-db
+teardown-test-containers: stop-test-relational-db stop-test-vector-db stop-alignscore-container
 
 setup-test-relational-db:
 	-@docker stop testdb
@@ -61,6 +60,18 @@ setup-test-vector-db:
 	docker run --name testvectordb \
 		-p 6334:6333 \
 		-d qdrant/qdrant
+
+setup-alignscore-container:
+	-@docker stop testalignscore
+	-@docker rm testalignscore
+	docker run --name testalignscore \
+		-p 5002:5001 \
+		-d alignscore-base
+	@sleep 10
+
+stop-alignscore-container:
+	@docker stop testalignscore
+	@docker rm testalignscore
 
 stop-test-relational-db:
 	@docker stop testdb

--- a/core_backend/app/__init__.py
+++ b/core_backend/app/__init__.py
@@ -8,7 +8,11 @@ from prometheus_client import (
     multiprocess,
 )
 
-from .configs.app_config import DOMAIN, QDRANT_COLLECTION_NAME, QDRANT_VECTOR_SIZE
+from .configs.app_config import (
+    DOMAIN,
+    QDRANT_COLLECTION_NAME,
+    QDRANT_VECTOR_SIZE,
+)
 from .prometheus_middleware import PrometheusMiddleware
 from .routers import admin, auth, manage_content, question_answer, whatsapp_qa
 from .utils import setup_logger

--- a/core_backend/app/configs/app_config.py
+++ b/core_backend/app/configs/app_config.py
@@ -38,3 +38,10 @@ BACKEND_ROOT_PATH = os.environ.get("BACKEND_ROOT_PATH", "")
 
 WHATSAPP_VERIFY_TOKEN = os.environ.get("WHATSAPP_VERIFY_TOKEN", "no-token-set")
 WHATSAPP_TOKEN = os.environ.get("WHATSAPP_TOKEN", "no-token-set")
+
+# Set below to `None" if not checking for LLM response alignment with content
+ALIGN_SCORE_METHOD = os.environ.get("ALIGN_SCORE_METHOD", "AlignScore")
+ALIGN_SCORE_THRESHOLD = os.environ.get("ALIGN_SCORE_THRESHOLD", 0.5)
+ALIGN_SCORE_API = os.environ.get(
+    "ALIGN_SCORE_API", "http://localhost:5001/alignscore_base"
+)

--- a/core_backend/app/llm_call/check_output.py
+++ b/core_backend/app/llm_call/check_output.py
@@ -1,0 +1,123 @@
+"""
+These are functions to check the LLM response
+"""
+from functools import wraps
+from typing import Any, Callable, TypedDict
+
+from ..configs.app_config import (
+    ALIGN_SCORE_API,
+    ALIGN_SCORE_METHOD,
+    ALIGN_SCORE_THRESHOLD,
+)
+from ..schemas import ResultState, UserQueryRefined, UserQueryResponse
+from ..utils import get_http_client, setup_logger
+
+logger = setup_logger("OUTPUT RAILS")
+
+STANDARD_FAILURE_MESSAGE = (
+    "Sorry, I am unable to find an answer to your question in my knowledge base."
+    "Please rephrase your question and ask a different one."
+)
+
+
+class Payload(TypedDict):
+    """
+    Payload for the AlignScore API
+    """
+
+    evidence: str
+    claim: str
+
+
+def check_align_score(func: Callable) -> Callable:
+    """
+    Check the alignment score
+    """
+
+    @wraps(func)
+    async def wrapper(
+        question: UserQueryRefined,
+        response: UserQueryResponse,
+        *args: Any,
+        **kwargs: Any,
+    ) -> UserQueryResponse:
+        """
+        Check the alignment score
+        """
+
+        llm_response = await func(question, response, *args, **kwargs)
+        if (
+            llm_response.state != ResultState.ERROR
+            and llm_response.llm_response is not None
+        ):
+            llm_response = await _check_align_score(llm_response)
+        return llm_response
+
+    return wrapper
+
+
+async def _check_align_score(llm_response: UserQueryResponse) -> UserQueryResponse:
+    """
+    Check the alignment score
+    """
+    evidence = _build_evidence(llm_response)
+    claim = llm_response.llm_response
+    if claim is not None:
+        payload = Payload(evidence=evidence, claim=claim)
+
+        if ALIGN_SCORE_METHOD is None:
+            logger.warning(
+                "No alignment score method specified but `check_align_score` was called"
+            )
+            return llm_response
+
+        elif ALIGN_SCORE_METHOD == "AlignScore":
+            align_score = await _get_alignScore_score(ALIGN_SCORE_API, payload)
+        else:
+            raise NotImplementedError(f"Unknown method {ALIGN_SCORE_METHOD}")
+
+        if align_score < float(ALIGN_SCORE_THRESHOLD):
+            llm_response.llm_response = STANDARD_FAILURE_MESSAGE
+            llm_response.state = ResultState.ERROR
+
+        llm_response.debug_info["factual_consistency"] = {
+            "method": "AlignScore",
+            "score": align_score,
+        }
+    else:
+        logger.warning(
+            (
+                "No LLM response found in the LLM response but "
+                "`check_align_score` was called"
+            )
+        )
+    return llm_response
+
+
+async def _get_alignScore_score(api_url: str, payload: Payload) -> float:
+    """
+    Get the alignment score from the AlignScore API
+    """
+    async with get_http_client().post(api_url, json=payload) as resp:
+        if resp.status != 200:
+            logger.error(f"AlignScore API request failed with status {resp.status}")
+            raise RuntimeError(
+                f"AlignScore API request failed with status {resp.status}"
+            )
+
+        result = await resp.json()
+    logger.info(f"AlignScore result: {result}")
+    result = result["alignscore"]
+
+    return result
+
+
+def _build_evidence(llm_response: UserQueryResponse) -> str:
+    """
+    Build the evidence used by the LLM response
+    """
+    evidence = ""
+    if llm_response.content_response is not None:
+        for _, result in llm_response.content_response.items():
+            evidence += result.response_text + "\n"
+    return evidence

--- a/core_backend/app/routers/admin.py
+++ b/core_backend/app/routers/admin.py
@@ -1,10 +1,15 @@
+from urllib.parse import urlparse
+
+from aiohttp.client_exceptions import ClientConnectorError
 from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from ..configs.app_config import ALIGN_SCORE_API, ALIGN_SCORE_METHOD
 from ..db.engine import get_async_session
+from ..utils import get_http_client
 
 router = APIRouter()
 
@@ -22,5 +27,33 @@ async def healthcheck(
         return JSONResponse(
             status_code=500, content={"message": f"Failed database connection: {e}"}
         )
+
+    if ALIGN_SCORE_METHOD == "AlignScore":
+        url = urlparse(ALIGN_SCORE_API)
+        healthcheck_url = f"{url.scheme}://{url.netloc}/healthcheck"
+        http_client = get_http_client()
+        try:
+            resp = await http_client.get(healthcheck_url)
+        except ClientConnectorError as e:
+            return JSONResponse(
+                status_code=500,
+                content={
+                    "message": (
+                        "Failed to connect to alignScore "
+                        f"container at: {healthcheck_url}."
+                        f" Error: {e}"
+                    )
+                },
+            )
+        if resp.status != 200:
+            return JSONResponse(
+                status_code=500,
+                content={
+                    "message": (
+                        "Response is not 200 from alignScore "
+                        f"healthcheck at: {healthcheck_url}"
+                    )
+                },
+            )
 
     return JSONResponse(status_code=200, content={"status": "ok"})

--- a/core_backend/app/routers/question_answer.py
+++ b/core_backend/app/routers/question_answer.py
@@ -17,6 +17,7 @@ from ..db.db_models import (
 )
 from ..db.engine import get_async_session
 from ..db.vector_db import get_qdrant_client, get_similar_content
+from ..llm_call.check_output import check_align_score
 from ..llm_call.llm_rag import get_llm_rag_answer
 from ..llm_call.parse_input import (
     classify_safety,
@@ -57,6 +58,7 @@ async def llm_response(
     return response
 
 
+@check_align_score
 @identify_language
 @translate_question
 @paraphrase_question

--- a/core_backend/app/utils.py
+++ b/core_backend/app/utils.py
@@ -1,6 +1,8 @@
 import logging
 from logging import Logger
 
+import aiohttp
+
 from .configs.app_config import LOG_LEVEL
 
 
@@ -47,3 +49,47 @@ def setup_logger(
     logger.addHandler(handler)
 
     return logger
+
+
+class HttpClient:
+    """
+    HTTP client for call other endpoints
+    """
+
+    session: aiohttp.ClientSession | None = None
+
+    def start(self) -> None:
+        """
+        Create AIOHTTP session
+        """
+        self.session = aiohttp.ClientSession()
+
+    async def stop(self) -> None:
+        """
+        Close AIOHTTP session
+        """
+        if self.session is not None:
+            await self.session.close()
+        self.session = None
+
+    def __call__(self) -> aiohttp.ClientSession:
+        """
+        Get AIOHTTP session
+        """
+        assert self.session is not None
+        return self.session
+
+
+_HTTP_CLIENT: aiohttp.ClientSession | None = None
+
+
+def get_http_client() -> aiohttp.ClientSession:
+    """
+    Get HTTP client
+    """
+    global _HTTP_CLIENT
+    if _HTTP_CLIENT is None or _HTTP_CLIENT.closed:
+        http_client = HttpClient()
+        http_client.start()
+        _HTTP_CLIENT = http_client()
+    return _HTTP_CLIENT

--- a/core_backend/tests/api/test.env
+++ b/core_backend/tests/api/test.env
@@ -8,3 +8,4 @@ QDRANT_PORT=6334
 
 LLM_MODEL="gpt-3.5-turbo"
 PROMETHEUS_MULTIPROC_DIR=/tmp
+ALIGN_SCORE_API="http://localhost:5002/alignscore_base"

--- a/core_backend/tests/api/test_admin.py
+++ b/core_backend/tests/api/test_admin.py
@@ -3,5 +3,5 @@ from fastapi.testclient import TestClient
 
 def test_healthcheck(client: TestClient) -> None:
     response = client.get("/healthcheck")
-    assert response.status_code == 200
+    assert response.status_code == 200, f"response: {response.json()}"
     assert response.json() == {"status": "ok"}

--- a/core_backend/tests/api/test_question_answer.py
+++ b/core_backend/tests/api/test_question_answer.py
@@ -1,9 +1,17 @@
+from typing import Any, Dict
+
 import pytest
 from fastapi.testclient import TestClient
 
 from core_backend.app.configs.app_config import (
     QDRANT_N_TOP_SIMILAR,
     QUESTION_ANSWER_SECRET,
+)
+from core_backend.app.llm_call.check_output import _build_evidence, _check_align_score
+from core_backend.app.schemas import (
+    ResultState,
+    UserQueryResponse,
+    UserQuerySearchResult,
 )
 
 
@@ -31,7 +39,7 @@ class TestEmbeddingsSearch:
             assert len(json_content_response.keys()) == int(QDRANT_N_TOP_SIMILAR)
 
     @pytest.fixture
-    def question_response(self, client: TestClient) -> None:
+    def question_response(self, client: TestClient) -> UserQueryResponse:
         response = client.post(
             "/embeddings-search",
             json={
@@ -50,7 +58,7 @@ class TestEmbeddingsSearch:
         token: str,
         expected_status_code: int,
         client: TestClient,
-        question_response: pytest.FixtureRequest,
+        question_response: Dict[str, Any],
     ) -> None:
         query_id = question_response["query_id"]
         feedback_secret_key = question_response["feedback_secret_key"]
@@ -67,7 +75,7 @@ class TestEmbeddingsSearch:
         assert response.status_code == expected_status_code
 
     def test_feedback_incorrect_secret(
-        self, client: TestClient, question_response: pytest.FixtureRequest
+        self, client: TestClient, question_response: Dict[str, Any]
     ) -> None:
         query_id = question_response["query_id"]
         response = client.post(
@@ -82,7 +90,7 @@ class TestEmbeddingsSearch:
         assert response.status_code == 400
 
     def test_feedback_incorrect_query_id(
-        self, client: TestClient, question_response: pytest.FixtureRequest
+        self, client: TestClient, question_response: Dict[str, Any]
     ) -> None:
         feedback_secret_key = question_response["feedback_secret_key"]
         response = client.post(
@@ -123,3 +131,69 @@ class TestLLMSearch:
         if expected_status_code == 200:
             content_response = response.json()["content_response"]
             assert len(content_response) != 0
+
+
+class TestAlignScore:
+    @pytest.fixture
+    def user_query_response(self) -> UserQueryResponse:
+        return UserQueryResponse(
+            query_id=124,
+            content_response={
+                1: UserQuerySearchResult(
+                    response_text="hello world",
+                    score=0.2,
+                ),
+                2: UserQuerySearchResult(
+                    response_text="goodbye universe",
+                    score=0.2,
+                ),
+            },
+            llm_response="This is a response",
+            feedback_secret_key="abc123",
+            debug_info={},
+            state=ResultState.IN_PROGRESS,
+        )
+
+    @pytest.mark.asyncio
+    async def test_score_less_than_threshold(
+        self, user_query_response: UserQueryResponse, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def mock_get_align_score(*args: Any, **kwargs: Any) -> float:
+            return 0.2
+
+        monkeypatch.setattr(
+            "core_backend.app.llm_call.check_output._get_alignScore_score",
+            mock_get_align_score,
+        )
+        monkeypatch.setattr(
+            "core_backend.app.llm_call.check_output.ALIGN_SCORE_THRESHOLD",
+            0.7,
+        )
+        update_query_response = await _check_align_score(user_query_response)
+        assert update_query_response.state == ResultState.ERROR
+        assert update_query_response.debug_info["factual_consistency"]["score"] == 0.2
+
+    @pytest.mark.asyncio
+    async def test_score_greater_than_threshold(
+        self, user_query_response: UserQueryResponse, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def mock_get_align_score(*args: Any, **kwargs: Any) -> float:
+            return 0.9
+
+        monkeypatch.setattr(
+            "core_backend.app.llm_call.check_output._get_alignScore_score",
+            mock_get_align_score,
+        )
+        monkeypatch.setattr(
+            "core_backend.app.llm_call.check_output.ALIGN_SCORE_THRESHOLD",
+            0.7,
+        )
+        update_query_response = await _check_align_score(user_query_response)
+        assert update_query_response.state == ResultState.IN_PROGRESS
+        assert update_query_response.debug_info["factual_consistency"]["score"] == 0.9
+
+    def test_build_evidence(
+        self, user_query_response: UserQueryResponse, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        evidence = _build_evidence(user_query_response)
+        assert evidence == "hello world\ngoodbye universe\n"

--- a/core_backend/tests/rails/test_language_indentification.py
+++ b/core_backend/tests/rails/test_language_indentification.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import List, Tuple
 
 import pytest
@@ -10,7 +11,7 @@ from core_backend.app.schemas import UserQueryRefined, UserQueryResponse
 pytestmark = pytest.mark.rails
 
 
-LANGUAGE_FILE = "tests/rails/data/language_identification.yaml"
+LANGUAGE_FILE = "data/language_identification.yaml"
 
 
 @pytest.fixture(scope="module")
@@ -23,14 +24,16 @@ def available_languages() -> list[str]:
 def read_test_data(file: str) -> List[Tuple[str, str]]:
     """Reads test data from file and returns a list of strings"""
 
-    with open(file, "r") as f:
+    file_path = Path(__file__).parent / file
+
+    with open(file_path, "r") as f:
         content = yaml.safe_load(f)
         return [(key, value) for key, values in content.items() for value in values]
 
 
 @pytest.mark.parametrize("language, content", read_test_data(LANGUAGE_FILE))
 def test_language_identification(
-    available_languages: pytest.FixtureRequest, language: str, content: str
+    available_languages: list[str], language: str, content: str
 ) -> None:
     """Test language identification"""
     question = UserQueryRefined(query_text=content, query_text_original=content)

--- a/core_backend/tests/rails/test_llm_response_in_context.py
+++ b/core_backend/tests/rails/test_llm_response_in_context.py
@@ -3,30 +3,45 @@ These tests check LLM response content validation functions.
 LLM response content validation functions are rails that check if the responses
 are based on the given context or not.
 """
-from typing import Dict, List, Literal
+from pathlib import Path
+from typing import List, Literal, Tuple
 
 import pytest
 import yaml
 
+from core_backend.app.configs.app_config import ALIGN_SCORE_API, ALIGN_SCORE_THRESHOLD
+from core_backend.app.llm_call.check_output import _get_alignScore_score
+
 pytestmark = pytest.mark.rails
 
-CONTEXT_RESPONSE_FILE = "tests/rails/data/llm_response_in_context.yaml"
+CONTEXT_RESPONSE_FILE = "data/llm_response_in_context.yaml"
 TestDataKeys = Literal["context", "statement", "expected", "reason"]
 
 
-def read_test_data(file: str) -> List[Dict[TestDataKeys, str]]:
+def read_test_data(file: str) -> List[Tuple]:
     """Reads test data from file and returns a list of strings"""
 
-    with open(file, "r") as f:
+    file_path = Path(__file__).parent / file
+
+    with open(file_path, "r") as f:
         content = yaml.safe_load(f)
-        return [dict(context=c["context"], **t) for c in content for t in c["tests"]]
+        return [(c["context"], *t.values()) for c in content for t in c["tests"]]
 
 
-def test_alignScore(llm_sentence: str, context: str, expected_answer: bool) -> None:
+@pytest.mark.asyncio(scope="module")
+@pytest.mark.parametrize(
+    "context, statement, expected, reason", read_test_data(CONTEXT_RESPONSE_FILE)
+)
+async def test_alignScore(
+    context: str, statement: str, expected: bool, reason: str
+) -> None:
     """
     This checks if alignScore returns the correct answer
     """
-    pass
+    score = await _get_alignScore_score(
+        ALIGN_SCORE_API, {"evidence": context, "claim": statement}
+    )
+    assert (score > float(ALIGN_SCORE_THRESHOLD)) == expected, reason + f" {score}"
 
 
 def test_llm_rag_validation(

--- a/core_backend/tests/rails/test_safety.py
+++ b/core_backend/tests/rails/test_safety.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from core_backend.app.configs.llm_prompts import SafetyClassification
@@ -7,14 +9,17 @@ from core_backend.app.schemas import ResultState, UserQueryRefined, UserQueryRes
 pytestmark = pytest.mark.rails
 
 
-PROMPT_INJECTION_FILE = "tests/rails/data/prompt_injection_data.txt"
-SAFE_MESSAGES_FILE = "tests/rails/data/safe_data.txt"
-INAPPROPRIATE_LANGUAGE_FILE = "tests/rails/data/inappropriate_lang.txt"
+PROMPT_INJECTION_FILE = "data/prompt_injection_data.txt"
+SAFE_MESSAGES_FILE = "data/safe_data.txt"
+INAPPROPRIATE_LANGUAGE_FILE = "data/inappropriate_lang.txt"
 
 
 def read_test_data(file: str) -> list[str]:
     """Reads test data from file and returns a list of strings"""
-    with open(file) as f:
+
+    file_path = Path(__file__).parent / file
+
+    with open(file_path) as f:
         return f.read().splitlines()
 
 

--- a/deployment/docker-compose.dev.yml
+++ b/deployment/docker-compose.dev.yml
@@ -6,7 +6,7 @@ services:
     environment:
       - POSTGRES_HOST=relational_db
   relational_db:
-    image: postgres:16.0-alpine
+    image: postgres:16.1-alpine
     restart: always
     env_file:
       - .env

--- a/deployment/docker-compose.dev.yml
+++ b/deployment/docker-compose.dev.yml
@@ -6,7 +6,7 @@ services:
     environment:
       - POSTGRES_HOST=relational_db
   relational_db:
-    image: postgres:15.4
+    image: postgres:16.0-alpine
     restart: always
     env_file:
       - .env

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -64,6 +64,18 @@ services:
       - ./data/certbot/conf:/etc/letsencrypt
       - ./data/certbot/www:/var/www/certbot
     entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
+  alignScore:
+    image: idinsight/aaq-backend:latest
+    profiles:
+      - alignScore
+      - optional-components
+    build:
+      context: ../optional_components/alignScore
+      dockerfile: Dockerfile
+    command: >
+      /usr/local/bin/python server.py --port=5001 --models=base
+    restart: always
+
 volumes:
   local_dynamic_storage:
   qdrant_volume:

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -65,7 +65,7 @@ services:
       - ./data/certbot/www:/var/www/certbot
     entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
   alignScore:
-    image: idinsight/aaq-backend:latest
+    image: idinsight/alignscore-base:latest
     profiles:
       - alignScore
       - optional-components

--- a/deployment/template.env
+++ b/deployment/template.env
@@ -43,3 +43,6 @@ CONTENT_READONLY_PASSWORD="readonly-prod"
 
 # Temporary folder for prometheus gunicorn multiprocess
 PROMETHEUS_MULTIPROC_DIR=/tmp
+
+# The URL to where AlignScore model is running
+ALIGN_SCORE_API=http://alignScore:5001/alignscore_base

--- a/optional_components/alignScore/Dockerfile
+++ b/optional_components/alignScore/Dockerfile
@@ -46,4 +46,6 @@ RUN python server.py --initialize-only
 EXPOSE 5001
 
 # Start the AlignScore server as the default command
-CMD ["usr/local/bin/python", "server.py", "--port=5001", "--models=base"]
+CMD ["/usr/local/bin/python", "server.py", "--port=5001", "--models=base"]
+
+HEALTHCHECK CMD curl -f http://localhost:5001/healthcheck || exit 1

--- a/optional_components/alignScore/Dockerfile
+++ b/optional_components/alignScore/Dockerfile
@@ -1,0 +1,49 @@
+# Use python:3.10 as the base image
+FROM python:3.10
+
+# Install git
+RUN apt-get update && apt-get install -y git
+
+# Set working directory
+WORKDIR /app
+
+# Clone and install the alignscore package
+RUN git clone https://github.com/IDinsight/AlignScore.git
+WORKDIR /app/AlignScore
+RUN pip install .
+
+# Download the Spacy en_core_web_sm model
+RUN python -m spacy download en_core_web_sm
+
+# Download the AlignScore base checkpoint
+RUN curl -OL https://huggingface.co/yzha/AlignScore/resolve/main/AlignScore-base.ckpt
+
+# Uncomment the line below to also download the large model
+# RUN curl -OL https://huggingface.co/yzha/AlignScore/resolve/main/AlignScore-large.ckpt
+
+# Switch
+WORKDIR /app
+
+# Copy the source code
+COPY . /app
+
+# Install the minimal set of requirements for AlignScore Server
+RUN pip install -r requirements.txt
+
+# Download the punkt model to speed up start time
+RUN python -c "import nltk; nltk.download('punkt')"
+
+# Set the ALIGN_SCORE_PATH environment variable
+ENV ALIGN_SCORE_PATH=/app/AlignScore
+
+# Set the device on which the model should load e.g., "cpu", "cuda:0", etc.
+ENV ALIGN_SCORE_DEVICE=cpu
+
+# Initialize the models
+RUN python server.py --initialize-only
+
+# Expose a port for the server
+EXPOSE 5001
+
+# Start the AlignScore server as the default command
+CMD ["usr/local/bin/python", "server.py", "--port=5001", "--models=base"]

--- a/optional_components/alignScore/requirements.txt
+++ b/optional_components/alignScore/requirements.txt
@@ -1,0 +1,5 @@
+pydantic==1.10.9
+fastapi==0.103.1
+starlette==0.27.0
+typer==0.7.0
+uvicorn==0.23.2

--- a/optional_components/alignScore/server.py
+++ b/optional_components/alignScore/server.py
@@ -1,0 +1,128 @@
+import os
+from functools import lru_cache
+from typing import List, Literal
+
+import nltk
+import typer
+import uvicorn
+from alignscore import AlignScore
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+# Make sure we have the punkt tokenizer downloaded.
+nltk.download("punkt")
+
+models_path = os.environ.get("ALIGN_SCORE_PATH")
+
+if models_path is None:
+    raise ValueError(
+        "Please set the ALIGN_SCORE_PATH environment variable "
+        "to point to the AlignScore checkpoints folder. "
+    )
+
+app = FastAPI()
+
+device = os.environ.get("ALIGN_SCORE_DEVICE", "cpu")
+
+
+@lru_cache
+def get_model(model: Literal["base", "large"]) -> AlignScore:
+    """Initialize a model.
+
+    Args
+        model: The type of the model to be loaded, i.e. "base", "large".
+    """
+    if models_path is None:
+        raise ValueError(
+            "Please set the ALIGN_SCORE_PATH environment variable "
+            "to point to the AlignScore checkpoints folder. "
+        )
+
+    return AlignScore(
+        model="roberta-base",
+        batch_size=32,
+        device=device,
+        ckpt_path=os.path.join(models_path, f"AlignScore-{model}.ckpt"),
+        evaluation_mode="nli_sp",
+    )
+
+
+class AlignScoreRequest(BaseModel):
+    """The request body for the AlignScore endpoints."""
+
+    evidence: str
+    claim: str
+
+
+class AlignScoreResponse(BaseModel):
+    """The response body for the AlignScore endpoints."""
+
+    alignscore: float
+
+
+@app.get("/")
+def hello_world() -> str:
+    """Welcome message."""
+
+    welcome_str = (
+        "This is a development server to host AlignScore models.\n"
+        "<br>Hit the /alignscore_base or alignscore_large endpoints with "
+        "a POST request containing evidence and claim.\n"
+        '<br>Example: curl -X POST -d \'{"evidence":"evidence","claim":"claim"}\''
+        " -H 'Content-Type: application/json' http://localhost:5001/alignscore_base"
+    )
+    return welcome_str
+
+
+def get_alignscore(model: AlignScore, evidence: str, claim: str) -> AlignScoreResponse:
+    """Wrapper for AlignScore"""
+    return AlignScoreResponse(
+        alignscore=model.score(contexts=[evidence], claims=[claim])[0]
+    )
+
+
+@app.post("/alignscore_base")
+def alignscore_base(request: AlignScoreRequest) -> AlignScoreResponse:
+    """Get the AlignScore for a given evidence and claim using the base model."""
+    model = get_model("base")
+    return get_alignscore(model, request.evidence, request.claim)
+
+
+@app.post("/alignscore_large")
+def alignscore_large(request: AlignScoreRequest) -> AlignScoreResponse:
+    """Get the AlignScore for a given evidence and claim using the large model."""
+    model = get_model("large")
+    return get_alignscore(model, request.evidence, request.claim)
+
+
+cli_app = typer.Typer()
+
+
+@cli_app.command()
+def start(
+    port: int = typer.Option(
+        default=5000, help="The port that the server should listen on. "
+    ),
+    models: List[str] = typer.Option(
+        default=["base"],
+        help="The list of models to be loaded on startup",
+    ),
+    initialize_only: bool = typer.Option(
+        default=False, help="Whether to run only the initialization for the models."
+    ),
+) -> None:
+    """CLI app for AlignScore server."""
+    # Preload the models
+    for model in models:
+        typer.echo(f"Pre-loading model {model}.")
+        get_model(model)
+
+    if initialize_only:
+        print("Initialization successful.")
+    else:
+        uvicorn.run(app, host="0.0.0.0", port=port)
+
+
+if __name__ == "__main__":
+    """Run the typer cli app"""
+    cli_app()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,4 @@ filterwarnings = [
 markers = [
     "rails: marks tests that are testing rails. These call an LLM service."
 ]
+asyncio_mode = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,14 +2,14 @@
 disallow_untyped_defs = true
 
 [[tool.mypy.overrides]]
-module = ['litellm']
+module = ['litellm', "nltk", "alignscore"]
 ignore_missing_imports = true
 
 [tool.ruff]
 select = ["E", "F", "B", "Q", "I"]
 
 [tool.ruff.flake8-bugbear]
-extend-immutable-calls = ["fastapi.Depends", "fastapi.params.Depends"]
+extend-immutable-calls = ["fastapi.Depends", "fastapi.params.Depends","typer.Option"]
 
 [tool.pytest.ini_options]
 filterwarnings = [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ black==23.9.1
 ruff-lsp==0.0.39
 mypy==1.5.1
 pytest==7.4.2
+pytest-asyncio==0.23.2
 httpx==0.25.0
 trio==0.22.2
 mkdocs-material==9.4.5


### PR DESCRIPTION
Reviewer: @amiraliemami 

Estimate: 2 hrs

----

# Added AlignScore as docker image

## Ticket

Fixes: [AAQ-254](https://idinsight.atlassian.net/browse/AAQ-254)

## Description, Motivation and Context

Added a new decorator that checks if claims being made in the `llm_response` are consistent with data provided in the context.

### Goal

Output guardrails

### Changes

* Added new optional docker containers. 
* Added tests
* New workflow to create image
* Updated old tests
* Lots of clean up

## How Has This Been Tested?

* New test cases
* Updated old test case
* You can also run the the extra `rails` test from `aaq-core/core_backend` using
Not all tests will pass and that's ok.

```
cd optional_components/alignScore
docker build -t alignscore-base .
docker run -p 5001:5001 --name align-score-local --detach 'alignscore-base'
cd ../../core_backend
pytest -m rails -k "test_alignScore" -vv
```
**Note: remember to export your OPENAI key before running these**

* Start up containers and use SwaggerUI to test backend `\healthcheck` and `\llm-response` endpoints

## Next steps
- Added the same rail using GPT4
- Add documentation.

There are tickets for both for this sprint.

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have updated the automated tests (if applicable)
- [x] I have written [good commit messages][1]
- [x] I have updated the README file (if applicable)
- [] I have updated affected documentation (if applicable)

[1]: http://chris.beams.io/posts/git-commit/


[AAQ-254]: https://idinsight.atlassian.net/browse/AAQ-254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ