### PR TITLE
AAQ-271: Bug fix: Improved translation tests

### DIFF
--- a/core_backend/app/routers/question_answer.py
+++ b/core_backend/app/routers/question_answer.py
@@ -57,10 +57,10 @@ async def llm_response(
     return response
 
 
-@classify_safety
-@translate_question
 @identify_language
+@translate_question
 @paraphrase_question
+@classify_safety
 async def get_llm_answer(
     user_query_refined: UserQueryRefined,
     response: UserQueryResponse,


### PR DESCRIPTION
Reviewer: @suzinyou 

Estimate: 10 mins

----

# Bug fix: 

## Ticket

Fixes: [AAQ-271](https://idinsight.atlassian.net/browse/AAQ-271)

## Description, Motivation and Context

There is a dependency between identify language and translation that is not captured in the tests.
This fixes that.

## How Has This Been Tested?

Test now pass.

To make them fail:
- Remove the `identify_language` decorator; or
- Move the `identify_language` decorator to below `translate_questions` 

<img width="623" alt="image" src="https://github.com/IDinsight/aaq-core/assets/14125957/5faf8198-9ec5-4897-81a1-beca6c5cd473">

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have updated the automated tests (if applicable)
- [x] I have written [good commit messages][1]
- [x] I have updated the README file (if applicable)
- [x] I have updated affected documentation (if applicable)

[1]: http://chris.beams.io/posts/git-commit/


[AAQ-271]: https://idinsight.atlassian.net/browse/AAQ-271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ