### PR TITLE
Split Botpress docker compose file to allow for connecting to DBs hosted elsewhere 

### DIFF
--- a/chat_managers/botpress_v12/deployment/docker-compose-postgres.yml
+++ b/chat_managers/botpress_v12/deployment/docker-compose-postgres.yml
@@ -1,4 +1,4 @@
-version: "1"
+version: "3"
 services:
   botpress:
     depends_on:

--- a/chat_managers/botpress_v12/deployment/docker-compose-postgres.yml
+++ b/chat_managers/botpress_v12/deployment/docker-compose-postgres.yml
@@ -1,0 +1,13 @@
+version: "1"
+services:
+  botpress:
+    depends_on:
+      - postgres
+  postgres:
+    image: postgres:11.2-alpine
+    env_file:
+      - .env
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+volumes:
+  pgdata:

--- a/chat_managers/botpress_v12/deployment/docker-compose.yml
+++ b/chat_managers/botpress_v12/deployment/docker-compose.yml
@@ -1,22 +1,13 @@
-version: "1"
+version: "2"
 services:
   botpress:
     image: botpress/server:v12_31_3
     environment:
-      - DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:${PGPORT}/${POSTGRES_DB}
+      - DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOSTNAME}:${PGPORT}/${POSTGRES_DB}
     env_file:
       - .env
-    depends_on:
-      - postgres
     volumes:
       - ./build/botpress/data:/botpress/data
-
-  postgres:
-    image: postgres:11.2-alpine
-    env_file:
-      - .env
-    volumes:
-      - pgdata:/var/lib/postgresql/data
 
   nginx:
     image: nginx:1.25-alpine
@@ -42,6 +33,3 @@ services:
       - ./data/certbot/conf:/etc/letsencrypt
       - ./data/certbot/www:/var/www/certbot
     entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
-
-volumes:
-  pgdata:

--- a/chat_managers/botpress_v12/deployment/docker-compose.yml
+++ b/chat_managers/botpress_v12/deployment/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - .env.nginx
 
   certbot:
-    image: certbot/certbot
+    image: certbot/certbot:v2.8.0
     restart: always
     volumes:
       - ./data/certbot/conf:/etc/letsencrypt

--- a/chat_managers/botpress_v12/deployment/docker-compose.yml
+++ b/chat_managers/botpress_v12/deployment/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "3"
 services:
   botpress:
     image: botpress/server:v12_31_3

--- a/chat_managers/botpress_v12/deployment/template.env
+++ b/chat_managers/botpress_v12/deployment/template.env
@@ -1,6 +1,7 @@
 # EXTERNAL_URL=http://localhost/
 
-PGPORT=5435
-POSTGRES_DB=botpress_db
-POSTGRES_PASSWORD=secretpw
+POSTGRES_HOSTNAME=postgres # should be name of postgres container if running locally
+PGPORT=5432
 POSTGRES_USER=postgres
+POSTGRES_PASSWORD=secretpw
+POSTGRES_DB=botpress_db

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -58,7 +58,7 @@ services:
     env_file:
       - .env.nginx
   certbot:
-    image: certbot/certbot
+    image: certbot/certbot:v2.8.0
     restart: always
     volumes:
       - ./data/certbot/conf:/etc/letsencrypt

--- a/docs/other-components/chat_managers/botpress_v12.md
+++ b/docs/other-components/chat_managers/botpress_v12.md
@@ -12,11 +12,14 @@ Note: [Botpress v12](https://github.com/botpress/v12/) is open-source and availa
 
 **Step 2:** Copy `template.env` to `.env` and edit it to set the variables
 
+    POSTGRES_HOSTNAME=
     PGPORT=
-    POSTGRES_DB=
-    POSTGRES_PASSWORD=
     POSTGRES_USER=
+    POSTGRES_PASSWORD=
+    POSTGRES_DB=
     ...
+
+!!! note "If running a postgres database locally with docker compose (as in Option 2 of Step 5), `POSTGRES_HOSTNAME` should be set to the name of that container, which is `postgres` in our case (see `docker-compose-postgres.yml`)."
 
 **Step 3:** Copy `template.env.nginx` to `.env.nginx` and edit it to set the variables
 
@@ -29,7 +32,13 @@ Note: [Botpress v12](https://github.com/botpress/v12/) is open-source and availa
 
 **Step 5:** Run docker compose
 
+Option 1 - If you already have a postgres database that you want botpress to connect to, just run:
+
     docker compose -f docker-compose.yml -p botpress-stack up -d --build
+
+Option 2 - Otherwise, run the following to also create a postgres database locally that botpress can use:
+
+    docker compose -f docker-compose.yml -f docker-compose-postgres.yml -p botpress-stack up -d --build
 
 You can now access Botpress at `https://[DOMAIN]/`
 

--- a/docs/other-components/chat_managers/botpress_v12.md
+++ b/docs/other-components/chat_managers/botpress_v12.md
@@ -44,7 +44,7 @@ You can now access Botpress at `https://[DOMAIN]/`
 
 **Step 6:** Shutdown containers
 
-    docker compose -f docker-compose.yml -p botpress-stack down
+Run the docker compose command you ran before but with `down` instead of `up -d --build`
 
 ### Option 2 - Via Docker
 


### PR DESCRIPTION
Reviewer: @suzinyou  
Estimate: 20mins

----

# Split Botpress docker compose file to allow for connecting to DBs hosted elsewhere 

## Ticket

Implements [AAQ-275](https://idinsight.atlassian.net/browse/AAQ-275?atlOrigin=eyJpIjoiYzJmYjdjNDUzNDRjNGQ2ZjgyYWJlMWRlZjZhYTI0MDYiLCJwIjoiaiJ9)

Also adds [AAQ-245](https://idinsight.atlassian.net/browse/AAQ-245?atlOrigin=eyJpIjoiZmI2NGUyNWVmYzIxNGUxYmJjYjNjZDk3ZDViNmQ5MzIiLCJwIjoiaiJ9) (certbot image version number)

## Description, Motivation and Context

### Goal

Split up docker compose file so that the local database container is optional and allow setting of env vars for connecting to external dbs.

### Changes

- Docker compose files
- .env template
- Docs

## How Has This Been Tested?

- See docs for deploying with or without the db. 
- The running with the db in the docker network works
- BUT setting env vars to  connect to RDS still results in an error from Botpress "hostname postgres not found". 
    - Need to test with separately hosted local DB to see if the issue mentioned above is from Botpress itself or AWS (EC2/routing/RDS stuff).

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [wip] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [-] I have updated the automated tests (if applicable)
- [x] I have written [good commit messages][1]
- [-] I have updated the README file (if applicable)
- [x] I have updated affected documentation (if applicable)

[1]: http://chris.beams.io/posts/git-commit/


[AAQ-275]: https://idinsight.atlassian.net/browse/AAQ-275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[AAQ-245]: https://idinsight.atlassian.net/browse/AAQ-245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ