### PR TITLE
HOTFIX: Upgraded `mkdocs-material` version in github actions

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -21,7 +21,8 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install mkdocs-material==9.4.5 \
+      - run: pip install mkdocs-material==9.5.3 \
           pymdown-extensions==10.3 \
-          mkdocs-glightbox==0.3.4
+          mkdocs-glightbox==0.3.4 \
+          mkdocs-material-extensions==1.3.1
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
We upgraded `mkdocs-material` but I forgot to upgrade the version that GA deploys.