### PR TITLE
[AAQ-281] Multilanguage content support

### DIFF
--- a/core_backend/Makefile
+++ b/core_backend/Makefile
@@ -35,9 +35,9 @@ run-tests:
 	python -m pytest -rPQ -m "not rails"
 
 # Test DBs
-setup-test-containers: setup-test-relational-db setup-test-vector-db setup-alignscore-container
+setup-test-containers: setup-test-relational-db setup-test-vector-db
 
-teardown-test-containers: stop-test-relational-db stop-test-vector-db stop-alignscore-container
+teardown-test-containers: stop-test-relational-db stop-test-vector-db
 
 setup-test-relational-db:
 	-@docker stop testdb

--- a/core_backend/app/configs/app_config.py
+++ b/core_backend/app/configs/app_config.py
@@ -17,7 +17,7 @@ QDRANT_HOST = os.environ.get("QDRANT_HOST", "localhost")
 
 QDRANT_COLLECTION_NAME = os.environ.get("QDRANT_COLLECTION_NAME", "default_collection")
 QDRANT_VECTOR_SIZE = os.environ.get("QDRANT_VECTOR_SIZE", "1536")
-QDRANT_N_TOP_SIMILAR = os.environ.get("QDRANT_N_TOP_SIMILAR", "4")
+QDRANT_N_TOP_SIMILAR = os.environ.get("QDRANT_N_TOP_SIMILAR", "3")
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")  # Will be none if not set
 EMBEDDING_MODEL = os.environ.get("EMBEDDING_MODEL", "text-embedding-ada-002")
 
@@ -47,3 +47,8 @@ ALIGN_SCORE_THRESHOLD = os.environ.get("ALIGN_SCORE_THRESHOLD", 0.7)
 ALIGN_SCORE_API = os.environ.get(
     "ALIGN_SCORE_API", "http://localhost:5001/alignscore_base"
 )
+
+# Minimum number of content to use as context for LLM response.
+# If it is greater than QDRANT_N_TOP_SIMILAR, only QDRANT_N_TOP_SIMILAR top content will
+# be used.
+MIN_LLM_CONTEXT_CONTENT = os.environ.get("MIN_CONTENT", "3")

--- a/core_backend/app/configs/app_config.py
+++ b/core_backend/app/configs/app_config.py
@@ -51,4 +51,4 @@ ALIGN_SCORE_API = os.environ.get(
 # Minimum number of content to use as context for LLM response.
 # If it is greater than QDRANT_N_TOP_SIMILAR, only QDRANT_N_TOP_SIMILAR top content will
 # be used.
-MIN_LLM_CONTEXT_CONTENT = os.environ.get("MIN_CONTENT", "3")
+MIN_LLM_CONTEXT_CONTENT = os.environ.get("MIN_CONTENT", "1")

--- a/core_backend/app/configs/llm_prompts.py
+++ b/core_backend/app/configs/llm_prompts.py
@@ -65,9 +65,9 @@ class IdentifiedLanguage(str, Enum):
     """
 
     ENGLISH = "ENGLISH"
-    XHOSA = "XHOSA"
-    ZULU = "ZULU"
-    AFRIKAANS = "AFRIKAANS"
+    # XHOSA = "XHOSA"
+    # ZULU = "ZULU"
+    # AFRIKAANS = "AFRIKAANS"
     HINDI = "HINDI"
     UNKNOWN = "UNKNOWN"
 
@@ -127,8 +127,8 @@ ANSWER_QUESTION_PROMPT = """
     You are a high-performing question answering bot.
     You support a maternal and child health chatbot.
 
-    Answer the user query in natural language by rewording the
-    following FAQ found below. Address the question directly and do not
+    Answer the user query in {response_language} using the information provided in the
+    FAQ found below. Address the question directly and do not
     respond with anything that is outside of the context of the given FAQ.
 
     If the FAQ doesn't seem to answer the question, respond with

--- a/core_backend/app/configs/llm_prompts.py
+++ b/core_backend/app/configs/llm_prompts.py
@@ -112,14 +112,15 @@ TRANSLATE_INPUT = f"""
 
 # ---- Paraphrase question
 PARAPHRASE_FAILED_MESSAGE = "ERROR: CAN'T PARAPHRASE"
-PARAPHRASE_INPUT = f"""
+PARAPHRASE_INPUT = (
+    """
     You are a high-performing paraphrase bot.
     You support a question-answering service.
-    The user has asked a question in English, paraphrase it to focus on
+    The user has asked a question in {query_language}. Paraphrase it to focus on
     the question. Be succinct and do not include any unnecessary information.
-    Ignore any redacted and offensive words.
-    If no paraphrase is possible, respond with {PARAPHRASE_FAILED_MESSAGE}
-    """
+    Ignore any redacted and offensive words. """
+    + f"If no paraphrase is possible, respond with {PARAPHRASE_FAILED_MESSAGE}"
+)
 
 # ----  Question answering bot
 

--- a/core_backend/app/configs/llm_prompts.py
+++ b/core_backend/app/configs/llm_prompts.py
@@ -59,7 +59,7 @@ class SafetyClassification(str, Enum):
 # ----  Language identification bot
 
 
-class IdentifiedLanguage(str, Enum):
+class Language(str, Enum):
     """
     Identified language of the user's input.
     """
@@ -72,7 +72,7 @@ class IdentifiedLanguage(str, Enum):
     UNKNOWN = "UNKNOWN"
 
     @classmethod
-    def _missing_(cls, value: str) -> IdentifiedLanguage:  # type: ignore[override]
+    def _missing_(cls, value: str) -> Language:  # type: ignore[override]
         """
         If language identified is not one of the above, it is classified as UNKNOWN.
         """

--- a/core_backend/app/configs/llm_prompts.py
+++ b/core_backend/app/configs/llm_prompts.py
@@ -126,7 +126,6 @@ PARAPHRASE_INPUT = (
 
 ANSWER_QUESTION_PROMPT = """
     You are a high-performing question answering bot.
-    You support a maternal and child health chatbot.
 
     Answer the user query in {response_language} using the information provided in the
     FAQ found below. Address the question directly and do not

--- a/core_backend/app/configs/llm_prompts.py
+++ b/core_backend/app/configs/llm_prompts.py
@@ -116,7 +116,7 @@ PARAPHRASE_INPUT = (
     """
     You are a high-performing paraphrase bot.
     You support a question-answering service.
-    The user has asked a question in ENGLISH.
+    The user has asked a question in {query_language}.
     Paraphrase it to focus on the question.
     Be succinct and do not include any unnecessary information.
     Ignore any redacted and offensive words. """
@@ -134,7 +134,7 @@ ANSWER_QUESTION_PROMPT = (
     "outside of the context of the given reference text. "
     "If the reference text doesn't seem to contain an answer the question, "
     "respond with 'Sorry, no relevant information found.'\n"
-    "Reference text: {content}"
+    "Reference text: {context}"
 )
 
 

--- a/core_backend/app/configs/llm_prompts.py
+++ b/core_backend/app/configs/llm_prompts.py
@@ -104,7 +104,7 @@ class Language(str, Enum):
 # ----  Translation bot
 TRANSLATE_FAILED_MESSAGE = "ERROR: CAN'T TRANSLATE"
 TRANSLATE_INPUT = f"""
-    You are a high-performing translation bot for low-resourced African languages.
+    You are a high-performing translation bot.
     You support a question-answering chatbot.
     If you are unable to translate the user's input,
     respond with {TRANSLATE_FAILED_MESSAGE}
@@ -116,25 +116,26 @@ PARAPHRASE_INPUT = (
     """
     You are a high-performing paraphrase bot.
     You support a question-answering service.
-    The user has asked a question in {query_language}. Paraphrase it to focus on
-    the question. Be succinct and do not include any unnecessary information.
+    The user has asked a question in ENGLISH.
+    Paraphrase it to focus on the question.
+    Be succinct and do not include any unnecessary information.
     Ignore any redacted and offensive words. """
     + f"If no paraphrase is possible, respond with {PARAPHRASE_FAILED_MESSAGE}"
 )
 
+
 # ----  Question answering bot
 
-ANSWER_QUESTION_PROMPT = """
-    You are a high-performing question answering bot.
-
-    Answer the user query in {response_language} using the information provided in the
-    FAQ found below. Address the question directly and do not
-    respond with anything that is outside of the context of the given FAQ.
-
-    If the FAQ doesn't seem to answer the question, respond with
-    'Sorry, no relevant information found.'
-
-    Found FAQ: {faq}"""
+ANSWER_QUESTION_PROMPT = (
+    "You are a high-performing question answering bot.\n"
+    "Answer the user query in {response_language} using the information "
+    "provided in the reference text found below. "
+    "Address the question directly and do not respond with anything that is "
+    "outside of the context of the given reference text. "
+    "If the reference text doesn't seem to contain an answer the question, "
+    "respond with 'Sorry, no relevant information found.'\n"
+    "Reference text: {content}"
+)
 
 
 class AlignmentScore(BaseModel):

--- a/core_backend/app/db/vector_db.py
+++ b/core_backend/app/db/vector_db.py
@@ -103,19 +103,26 @@ def get_search_results(
     n_similar: int,
 ) -> Dict[int, UserQuerySearchResult]:
     """Get similar content to given embedding and return search results"""
+    if question_language != question_language.UNKNOWN:
+        query_filter = (
+            Filter(
+                must=[
+                    FieldCondition(
+                        key="content_language",
+                        match=MatchValue(value=question_language.value),
+                    ),
+                ]
+            ),
+        )
+    else:
+        query_filter = None
+
     search_result = qdrant_client.search(
         collection_name=QDRANT_COLLECTION_NAME,
         query_vector=question_embedding,
         limit=n_similar,
         with_payload=PayloadSelectorInclude(include=["content_title", "content_text"]),
-        query_filter=Filter(
-            must=[
-                FieldCondition(
-                    key="content_language",
-                    match=MatchValue(value=question_language.value),
-                ),
-            ]
-        ),
+        query_filter=query_filter,
     )
 
     results_dict = {}

--- a/core_backend/app/db/vector_db.py
+++ b/core_backend/app/db/vector_db.py
@@ -79,7 +79,7 @@ async def get_similar_content_async(
     question: UserQueryRefined,
     qdrant_client: QdrantClient,
     n_similar: int,
-    question_language: Language = Language.ENGLISH,
+    question_language: Language = Language.UNKNOWN,
 ) -> Dict[int, UserQuerySearchResult]:
     """
     Get the most similar points in the vector db
@@ -103,7 +103,9 @@ def get_search_results(
     n_similar: int,
 ) -> Dict[int, UserQuerySearchResult]:
     """Get similar content to given embedding and return search results"""
-    if question_language != question_language.UNKNOWN:
+    if question_language == question_language.UNKNOWN:
+        query_filter = None
+    else:
         query_filter = Filter(
             must=[
                 FieldCondition(
@@ -112,14 +114,14 @@ def get_search_results(
                 ),
             ]
         )
-    else:
-        query_filter = None
 
     search_result = qdrant_client.search(
         collection_name=QDRANT_COLLECTION_NAME,
         query_vector=question_embedding,
         limit=n_similar,
-        with_payload=PayloadSelectorInclude(include=["content_title", "content_text"]),
+        with_payload=PayloadSelectorInclude(
+            include=["content_title", "content_text", "content_language"]
+        ),
         query_filter=query_filter,
     )
 

--- a/core_backend/app/db/vector_db.py
+++ b/core_backend/app/db/vector_db.py
@@ -104,15 +104,13 @@ def get_search_results(
 ) -> Dict[int, UserQuerySearchResult]:
     """Get similar content to given embedding and return search results"""
     if question_language != question_language.UNKNOWN:
-        query_filter = (
-            Filter(
-                must=[
-                    FieldCondition(
-                        key="content_language",
-                        match=MatchValue(value=question_language.value),
-                    ),
-                ]
-            ),
+        query_filter = Filter(
+            must=[
+                FieldCondition(
+                    key="content_language",
+                    match=MatchValue(value=question_language.value),
+                ),
+            ]
         )
     else:
         query_filter = None

--- a/core_backend/app/db/vector_db.py
+++ b/core_backend/app/db/vector_db.py
@@ -11,8 +11,6 @@ from qdrant_client.models import (
     VectorParams,
 )
 
-from core_backend.app.configs.llm_prompts import IdentifiedLanguage
-
 from ..configs.app_config import (
     EMBEDDING_MODEL,
     QDRANT_API_KEY,
@@ -21,6 +19,7 @@ from ..configs.app_config import (
     QDRANT_PORT,
     QDRANT_URL,
 )
+from ..configs.llm_prompts import Language
 from ..schemas import UserQueryBase, UserQuerySearchResult
 
 _qdrant_client: QdrantClient | None = None
@@ -67,10 +66,14 @@ def get_similar_content(
     """
     response = embedding(EMBEDDING_MODEL, question.query_text)
     question_embedding = response.data[0]["embedding"]
-    question_language = question.original_language.value
+    question_language = question.original_language
 
     return get_search_results(
-        question_embedding, question_language, qdrant_client, n_similar, qdrant_collection_name
+        question_embedding,
+        question_language,
+        qdrant_client,
+        n_similar,
+        qdrant_collection_name,
     )
 
 
@@ -85,16 +88,20 @@ async def get_similar_content_async(
     """
     response = await aembedding(EMBEDDING_MODEL, question.query_text)
     question_embedding = response.data[0]["embedding"]
-    question_language = question.original_language.value
+    question_language = question.original_language
 
     return get_search_results(
-        question_embedding, question_language, qdrant_client, n_similar, qdrant_collection_name
+        question_embedding,
+        question_language,
+        qdrant_client,
+        n_similar,
+        qdrant_collection_name,
     )
 
 
 def get_search_results(
     question_embedding: List[float],
-    question_language: IdentifiedLanguage,
+    question_language: Language,
     qdrant_client: QdrantClient,
     n_similar: int,
     qdrant_collection_name: str = QDRANT_COLLECTION_NAME,

--- a/core_backend/app/llm_call/llm_rag.py
+++ b/core_backend/app/llm_call/llm_rag.py
@@ -3,14 +3,14 @@ from .utils import _ask_llm_async
 
 
 async def get_llm_rag_answer(
-    question: str, faq_data: str, response_language: Language
+    question: str, content_text: str, response_language: Language
 ) -> str:
     """
     This function is used to get an answer from the LLM model.
     """
 
     prompt = ANSWER_QUESTION_PROMPT.format(
-        faq=faq_data, response_language=response_language.value
+        content=content_text, response_language=response_language.value
     )
 
     return await _ask_llm_async(question, prompt)

--- a/core_backend/app/llm_call/llm_rag.py
+++ b/core_backend/app/llm_call/llm_rag.py
@@ -3,14 +3,14 @@ from .utils import _ask_llm_async
 
 
 async def get_llm_rag_answer(
-    question: str, content_text: str, response_language: Language
+    question: str, context: str, response_language: Language
 ) -> str:
     """
     This function is used to get an answer from the LLM model.
     """
 
     prompt = ANSWER_QUESTION_PROMPT.format(
-        content=content_text, response_language=response_language.value
+        context=context, response_language=response_language.value
     )
 
     return await _ask_llm_async(question, prompt)

--- a/core_backend/app/llm_call/llm_rag.py
+++ b/core_backend/app/llm_call/llm_rag.py
@@ -1,16 +1,16 @@
-from ..configs.llm_prompts import ANSWER_QUESTION_PROMPT
+from ..configs.llm_prompts import ANSWER_QUESTION_PROMPT, IdentifiedLanguage
 from .utils import _ask_llm_async
 
 
 async def get_llm_rag_answer(
-    question: str, faq_data: str, response_language: str = "ENGLISH"
+    question: str, faq_data: str, response_language: IdentifiedLanguage
 ) -> str:
     """
     This function is used to get an answer from the LLM model.
     """
 
     prompt = ANSWER_QUESTION_PROMPT.format(
-        faq=faq_data, response_language=response_language
+        faq=faq_data, response_language=response_language.value
     )
 
     return await _ask_llm_async(question, prompt)

--- a/core_backend/app/llm_call/llm_rag.py
+++ b/core_backend/app/llm_call/llm_rag.py
@@ -2,11 +2,15 @@ from ..configs.llm_prompts import ANSWER_QUESTION_PROMPT
 from .utils import _ask_llm_async
 
 
-async def get_llm_rag_answer(question: str, faq_data: str) -> str:
+async def get_llm_rag_answer(
+    question: str, faq_data: str, response_language: str = "ENGLISH"
+) -> str:
     """
     This function is used to get an answer from the LLM model.
     """
 
-    prompt = ANSWER_QUESTION_PROMPT.format(faq=faq_data)
+    prompt = ANSWER_QUESTION_PROMPT.format(
+        faq=faq_data, response_language=response_language
+    )
 
     return await _ask_llm_async(question, prompt)

--- a/core_backend/app/llm_call/llm_rag.py
+++ b/core_backend/app/llm_call/llm_rag.py
@@ -1,9 +1,9 @@
-from ..configs.llm_prompts import ANSWER_QUESTION_PROMPT, IdentifiedLanguage
+from ..configs.llm_prompts import ANSWER_QUESTION_PROMPT, Language
 from .utils import _ask_llm_async
 
 
 async def get_llm_rag_answer(
-    question: str, faq_data: str, response_language: IdentifiedLanguage
+    question: str, faq_data: str, response_language: Language
 ) -> str:
     """
     This function is used to get an answer from the LLM model.

--- a/core_backend/app/llm_call/parse_input.py
+++ b/core_backend/app/llm_call/parse_input.py
@@ -218,7 +218,16 @@ async def _paraphrase_question(
     if response.state == ResultState.ERROR:
         return question, response
 
-    paraphrase_response = await _ask_llm_async(question.query_text, PARAPHRASE_INPUT)
+    orig_lang = question.original_language
+    if orig_lang is None:
+        lang = "ENGLISH"
+    else:
+        lang = orig_lang.value
+
+    paraphrase_response = await _ask_llm_async(
+        question.query_text,
+        PARAPHRASE_INPUT.format(query_language=lang),
+    )
     if paraphrase_response != PARAPHRASE_FAILED_MESSAGE:
         question.query_text = paraphrase_response
         response.debug_info["paraphrased_question"] = paraphrase_response

--- a/core_backend/app/llm_call/parse_input.py
+++ b/core_backend/app/llm_call/parse_input.py
@@ -10,7 +10,7 @@ from ..configs.llm_prompts import (
     PARAPHRASE_INPUT,
     TRANSLATE_FAILED_MESSAGE,
     TRANSLATE_INPUT,
-    IdentifiedLanguage,
+    Language,
     SafetyClassification,
 )
 from ..schemas import ResultState, UserQueryRefined, UserQueryResponse
@@ -98,12 +98,12 @@ async def _identify_language(
     """
     if response.state != ResultState.ERROR:
         identified_lang = await _ask_llm_async(
-            question.query_text, IdentifiedLanguage.get_prompt()
+            question.query_text, Language.get_prompt()
         )
-        if identified_lang in IdentifiedLanguage.get_supported_languages():
-            question.original_language = getattr(IdentifiedLanguage, identified_lang)
+        if identified_lang in Language.get_supported_languages():
+            question.original_language = getattr(Language, identified_lang)
         else:
-            question.original_language = IdentifiedLanguage.UNKNOWN
+            question.original_language = Language.UNKNOWN
 
         if question.original_language is not None:
             response.debug_info["original_language"] = question.original_language.value
@@ -142,7 +142,7 @@ async def _translate_question(
     """
 
     if (
-        question.original_language == IdentifiedLanguage.ENGLISH
+        question.original_language == Language.ENGLISH
         or response.state == ResultState.ERROR
     ):
         return question, response
@@ -156,8 +156,8 @@ async def _translate_question(
             )
         )
 
-    if question.original_language == IdentifiedLanguage.UNKNOWN:
-        supported_languages = ", ".join(IdentifiedLanguage.get_supported_languages())
+    if question.original_language == Language.UNKNOWN:
+        supported_languages = ", ".join(Language.get_supported_languages())
 
         response.llm_response = (
             STANDARD_FAILURE_MESSAGE

--- a/core_backend/app/llm_call/parse_input.py
+++ b/core_backend/app/llm_call/parse_input.py
@@ -218,15 +218,9 @@ async def _paraphrase_question(
     if response.state == ResultState.ERROR:
         return question, response
 
-    orig_lang = question.original_language
-    if orig_lang is None:
-        lang = "ENGLISH"
-    else:
-        lang = orig_lang.value
-
     paraphrase_response = await _ask_llm_async(
         question.query_text,
-        PARAPHRASE_INPUT.format(query_language=lang),
+        PARAPHRASE_INPUT.format(query_language=question.original_language.value),
     )
     if paraphrase_response != PARAPHRASE_FAILED_MESSAGE:
         question.query_text = paraphrase_response

--- a/core_backend/app/routers/manage_content.py
+++ b/core_backend/app/routers/manage_content.py
@@ -48,7 +48,10 @@ async def create_content(
     """
 
     payload = _create_payload_for_qdrant_upsert(
-        content.content_title, content.content_text, content.content_metadata
+        content.content_title,
+        content.content_text,
+        content.content_metadata,
+        content_language=content.content_language,
     )
 
     content_id = uuid.uuid4()
@@ -84,6 +87,7 @@ async def edit_content(
         content_title=content.content_title,
         content_text=content.content_text,
         metadata=old_content[0].payload or {},
+        content_language=content.content_language,
     )
     payload = payload.model_copy(update=content.content_metadata)
 
@@ -166,7 +170,10 @@ async def retrieve_content_by_id(
 
 
 def _create_payload_for_qdrant_upsert(
-    content_title: str, content_text: str, metadata: dict
+    content_title: str,
+    content_text: str,
+    metadata: dict,
+    content_language: str,
 ) -> QdrantPayload:
     """
     Create payload for qdrant upsert
@@ -174,6 +181,7 @@ def _create_payload_for_qdrant_upsert(
     payload_dict = metadata.copy()
     payload_dict["content_title"] = content_title
     payload_dict["content_text"] = content_text
+    payload_dict["content_language"] = content_language
     payload = QdrantPayload(**payload_dict)
     payload.updated_datetime_utc = datetime.utcnow()
 
@@ -219,10 +227,12 @@ def _convert_record_to_schema(record: Record) -> ContentRetrieve:
     updated_datetime = content_metadata.pop("updated_datetime_utc")
     content_title = content_metadata.pop("content_title")
     content_text = content_metadata.pop("content_text")
+    content_language = content_metadata.pop("content_language")
 
     return ContentRetrieve(
         content_title=content_title,
         content_text=content_text,
+        content_language=content_language,
         content_metadata=content_metadata,
         content_id=UUID(str(record.id)),
         created_datetime_utc=created_datetime,

--- a/core_backend/app/routers/manage_content.py
+++ b/core_backend/app/routers/manage_content.py
@@ -26,6 +26,7 @@ class QdrantPayload(BaseModel):
     # Ensure len("*{title}*\n\n{text}") <= 1600
     content_title: Annotated[str, StringConstraints(max_length=150)]
     content_text: Annotated[str, StringConstraints(max_length=1446)]
+    content_language: str = "ENGLISH"
 
     content_metadata: dict = Field(default_factory=dict)
     created_datetime_utc: datetime = Field(default_factory=datetime.utcnow)
@@ -222,12 +223,13 @@ def _convert_record_to_schema(record: Record) -> ContentRetrieve:
     """
     Convert qdrant_client.models.Record to ContentRetrieve schema
     """
-    content_metadata = record.payload or {}
-    created_datetime = content_metadata.pop("created_datetime_utc")
-    updated_datetime = content_metadata.pop("updated_datetime_utc")
-    content_title = content_metadata.pop("content_title")
-    content_text = content_metadata.pop("content_text")
-    content_language = content_metadata.pop("content_language")
+    payload = record.payload or {}
+    created_datetime = payload.pop("created_datetime_utc")
+    updated_datetime = payload.pop("updated_datetime_utc")
+    content_title = payload.pop("content_title")
+    content_text = payload.pop("content_text")
+    content_language = payload.pop("content_language")
+    content_metadata = payload.pop("content_metadata", {})
 
     return ContentRetrieve(
         content_title=content_title,

--- a/core_backend/app/routers/manage_content.py
+++ b/core_backend/app/routers/manage_content.py
@@ -27,7 +27,7 @@ class QdrantPayload(BaseModel):
     # Ensure len("*{title}*\n\n{text}") <= 1600
     content_title: Annotated[str, StringConstraints(max_length=150)]
     content_text: Annotated[str, StringConstraints(max_length=1446)]
-    content_language: str = Language.ENGLISH.value
+    content_language: str = Language.UNKNOWN.value
 
     created_datetime_utc: datetime = Field(default_factory=datetime.utcnow)
     updated_datetime_utc: datetime = Field(default_factory=datetime.utcnow)
@@ -49,9 +49,9 @@ async def create_content(
     """
 
     payload = _create_payload_for_qdrant_upsert(
-        content.content_title,
-        content.content_text,
-        content.content_metadata,
+        content_title=content.content_title,
+        content_text=content.content_text,
+        metadata=content.content_metadata,
         content_language=content.content_language,
     )
 

--- a/core_backend/app/routers/manage_content.py
+++ b/core_backend/app/routers/manage_content.py
@@ -231,7 +231,7 @@ def _convert_record_to_schema(record: Record) -> ContentRetrieve:
     updated_datetime = payload.pop("updated_datetime_utc")
     content_title = payload.pop("content_title")
     content_text = payload.pop("content_text")
-    content_language = payload.pop("content_language")
+    content_language = payload.pop("content_language", Language.UNKNOWN.value)
     content_metadata = payload
 
     return ContentRetrieve(

--- a/core_backend/app/routers/question_answer.py
+++ b/core_backend/app/routers/question_answer.py
@@ -79,10 +79,13 @@ async def get_llm_answer(
         user_query_refined, qdrant_client, int(QDRANT_N_TOP_SIMILAR)
     )
     response.content_response = content_response
-
+    content_full_text = (
+        f"Title: {content_response[0].retrieved_title}\n\n"
+        f"Text: {content_response[0].retrieved_text}"
+    )
     response.llm_response = await get_llm_rag_answer(
         user_query_refined.query_text,
-        content_response[0].retrieved_text,
+        content_full_text,
         response_language=user_query_refined.original_language,
     )
 

--- a/core_backend/app/routers/question_answer.py
+++ b/core_backend/app/routers/question_answer.py
@@ -81,8 +81,19 @@ async def get_llm_answer(
         user_query_refined, qdrant_client, int(QDRANT_N_TOP_SIMILAR)
     )
     response.content_response = content_response
+
+    # If we directly pass userquery_refined.original_language.value
+    # Mypy somehow thinks it is of type IdentifiedLanguage | None and complains.
+    orig_lang = user_query_refined.original_language
+    if orig_lang is None:
+        lang = "ENGLISH"
+    else:
+        lang = orig_lang.value
+        
     response.llm_response = await get_llm_rag_answer(
-        user_query_refined.query_text, content_response[0].retrieved_text
+        user_query_refined.query_text,
+        content_response[0].retrieved_text,
+        response_language=lang,
     )
 
     return response

--- a/core_backend/app/routers/question_answer.py
+++ b/core_backend/app/routers/question_answer.py
@@ -80,18 +80,10 @@ async def get_llm_answer(
     )
     response.content_response = content_response
 
-    # If we directly pass userquery_refined.original_language.value
-    # Mypy somehow thinks it is of type IdentifiedLanguage | None and complains.
-    orig_lang = user_query_refined.original_language
-    if orig_lang is None:
-        lang = "ENGLISH"
-    else:
-        lang = orig_lang.value
-        
     response.llm_response = await get_llm_rag_answer(
         user_query_refined.query_text,
         content_response[0].retrieved_text,
-        response_language=lang,
+        response_language=user_query_refined.original_language,
     )
 
     return response

--- a/core_backend/app/routers/question_answer.py
+++ b/core_backend/app/routers/question_answer.py
@@ -27,7 +27,6 @@ from ..llm_call.parse_input import (
     classify_safety,
     identify_language,
     paraphrase_question,
-    translate_question,
 )
 from ..schemas import (
     FeedbackBase,
@@ -64,7 +63,6 @@ async def llm_response(
 
 @check_align_score
 @identify_language
-@translate_question
 @paraphrase_question
 @classify_safety
 async def get_llm_answer(
@@ -148,7 +146,6 @@ async def embeddings_search(
 
 
 @identify_language
-@translate_question
 @paraphrase_question
 async def get_semantic_matches(
     user_query_refined: UserQueryRefined,

--- a/core_backend/app/routers/whatsapp_qa.py
+++ b/core_backend/app/routers/whatsapp_qa.py
@@ -10,7 +10,11 @@ from ..configs.app_config import WHATSAPP_TOKEN, WHATSAPP_VERIFY_TOKEN
 from ..db.db_models import save_wamessage_to_db, save_waresponse_to_db
 from ..db.engine import get_async_session
 from ..db.vector_db import get_qdrant_client, get_similar_content
-from ..schemas import UserQueryBase, WhatsAppIncoming, WhatsAppResponse
+from ..schemas import (
+    UserQueryRefined,
+    WhatsAppIncoming,
+    WhatsAppResponse,
+)
 
 router = APIRouter()
 
@@ -58,7 +62,11 @@ async def process_whatsapp_message(
                     asession=asession, incoming=incoming_to_process
                 )
 
-                message = UserQueryBase(query_text=msg_body, query_metadata={})
+                message = UserQueryRefined(
+                    query_text=msg_body,
+                    query_metadata={},
+                    query_text_original=msg_body,
+                )
                 content_response = get_similar_content(message, qdrant_client, 1)
                 top_faq = content_response[0].retrieved_text
                 data_obj = {

--- a/core_backend/app/schemas.py
+++ b/core_backend/app/schemas.py
@@ -4,7 +4,7 @@ from typing import Annotated, Dict, Literal, Optional
 
 from pydantic import UUID4, BaseModel, ConfigDict, StringConstraints
 
-from .configs.llm_prompts import IdentifiedLanguage
+from .configs.llm_prompts import Language
 
 AccessLevel = Literal["fullaccess", "readonly"]
 
@@ -36,7 +36,7 @@ class UserQueryRefined(UserQueryBase):
     """
 
     query_text_original: str
-    original_language: IdentifiedLanguage = IdentifiedLanguage.UNKNOWN
+    original_language: Language = Language.UNKNOWN
 
 
 class UserQuerySearchResult(BaseModel):

--- a/core_backend/app/schemas.py
+++ b/core_backend/app/schemas.py
@@ -36,7 +36,7 @@ class UserQueryRefined(UserQueryBase):
     """
 
     query_text_original: str
-    original_language: IdentifiedLanguage | None = None
+    original_language: IdentifiedLanguage = IdentifiedLanguage.UNKNOWN
 
 
 class UserQuerySearchResult(BaseModel):
@@ -86,6 +86,7 @@ class ContentCreate(BaseModel):
     # Ensure len("*{title}*\n\n{text}") <= 1600
     content_title: Annotated[str, StringConstraints(max_length=150)]
     content_text: Annotated[str, StringConstraints(max_length=1446)]
+    content_language: str = "ENGLISH"
     content_metadata: dict = {}
 
     model_config = ConfigDict(from_attributes=True)

--- a/core_backend/app/schemas.py
+++ b/core_backend/app/schemas.py
@@ -46,6 +46,7 @@ class UserQuerySearchResult(BaseModel):
 
     retrieved_title: str
     retrieved_text: str
+    retrieved_language: str
     score: float
 
     model_config = ConfigDict(from_attributes=True)

--- a/core_backend/app/schemas.py
+++ b/core_backend/app/schemas.py
@@ -87,7 +87,7 @@ class ContentCreate(BaseModel):
     # Ensure len("*{title}*\n\n{text}") <= 1600
     content_title: Annotated[str, StringConstraints(max_length=150)]
     content_text: Annotated[str, StringConstraints(max_length=1446)]
-    content_language: str = "ENGLISH"
+    content_language: str = Language.UNKNOWN.value
     content_metadata: dict = {}
 
     model_config = ConfigDict(from_attributes=True)

--- a/core_backend/tests/api/conftest.py
+++ b/core_backend/tests/api/conftest.py
@@ -49,7 +49,6 @@ def faq_contents(client: TestClient) -> None:
             content["content_title"],
             content["content_text"],
             metadata,
-            content["content_language"],
         )
         points.append(
             PointStruct(

--- a/core_backend/tests/api/conftest.py
+++ b/core_backend/tests/api/conftest.py
@@ -16,7 +16,7 @@ from core_backend.app.configs.app_config import (
     QDRANT_COLLECTION_NAME,
     QDRANT_VECTOR_SIZE,
 )
-from core_backend.app.configs.llm_prompts import AlignmentScore, IdentifiedLanguage
+from core_backend.app.configs.llm_prompts import AlignmentScore, Language
 from core_backend.app.db.vector_db import get_qdrant_client
 from core_backend.app.llm_call import check_output, parse_input
 from core_backend.app.routers.manage_content import _create_payload_for_qdrant_upsert
@@ -46,7 +46,10 @@ def faq_contents(client: TestClient) -> None:
         ]
         metadata = content.get("content_metadata", {})
         payload = _create_payload_for_qdrant_upsert(
-            content["content_title"], content["content_text"], metadata
+            content["content_title"],
+            content["content_text"],
+            metadata,
+            content["content_language"],
         )
         points.append(
             PointStruct(
@@ -116,7 +119,7 @@ async def mock_identify_language(
     """
     Monkeypatch call to LLM language identification service
     """
-    question.original_language = IdentifiedLanguage.ENGLISH
+    question.original_language = Language.ENGLISH
     response.debug_info["original_language"] = "ENGLISH"
 
     return question, response

--- a/core_backend/tests/api/conftest.py
+++ b/core_backend/tests/api/conftest.py
@@ -49,6 +49,7 @@ def faq_contents(client: TestClient) -> None:
             content["content_title"],
             content["content_text"],
             metadata,
+            Language.ENGLISH.value,
         )
         points.append(
             PointStruct(

--- a/core_backend/tests/api/test_manage_content.py
+++ b/core_backend/tests/api/test_manage_content.py
@@ -303,6 +303,7 @@ class TestUpsertContentToQdrant:
         [
             ("title1", "content text 1", {}),
             ("title 1", "content text 2", {"meta_key": "meta_value"}),
+            ("title 1", "content text 2", {"meta_key": "meta_value"}),
         ],
     )
     def test_upsert_content_to_qdrant_return_value(

--- a/core_backend/tests/api/test_manage_content.py
+++ b/core_backend/tests/api/test_manage_content.py
@@ -303,7 +303,6 @@ class TestUpsertContentToQdrant:
         [
             ("title1", "content text 1", {}),
             ("title 1", "content text 2", {"meta_key": "meta_value"}),
-            ("title 1", "content text 2", {"meta_key": "meta_value"}),
         ],
     )
     def test_upsert_content_to_qdrant_return_value(

--- a/core_backend/tests/api/test_question_answer.py
+++ b/core_backend/tests/api/test_question_answer.py
@@ -143,11 +143,13 @@ class TestAlignScore:
                 1: UserQuerySearchResult(
                     retrieved_title="World",
                     retrieved_text="hello world",
+                    retrieved_language="ENGLISH",
                     score=0.2,
                 ),
                 2: UserQuerySearchResult(
                     retrieved_title="Universe",
                     retrieved_text="goodbye universe",
+                    retrieved_language="ENGLISH",
                     score=0.2,
                 ),
             },

--- a/core_backend/tests/rails/test_language_indentification.py
+++ b/core_backend/tests/rails/test_language_indentification.py
@@ -4,7 +4,7 @@ from typing import List, Tuple
 import pytest
 import yaml
 
-from core_backend.app.configs.llm_prompts import IdentifiedLanguage
+from core_backend.app.configs.llm_prompts import Language
 from core_backend.app.llm_call.parse_input import _identify_language
 from core_backend.app.schemas import UserQueryRefined, UserQueryResponse
 
@@ -18,7 +18,7 @@ LANGUAGE_FILE = "data/language_identification.yaml"
 def available_languages() -> list[str]:
     """Returns a list of available languages"""
 
-    return [lang.value for lang in IdentifiedLanguage]
+    return [lang.value for lang in Language]
 
 
 def read_test_data(file: str) -> List[Tuple[str, str]]:
@@ -32,7 +32,7 @@ def read_test_data(file: str) -> List[Tuple[str, str]]:
 
 
 @pytest.mark.parametrize("language, content", read_test_data(LANGUAGE_FILE))
-def test_language_identification(
+async def test_language_identification(
     available_languages: list[str], language: str, content: str
 ) -> None:
     """Test language identification"""
@@ -45,5 +45,5 @@ def test_language_identification(
     )
     if language not in available_languages:
         language = "UNKNOWN"
-    _, response = _identify_language(question, response)
+    _, response = await _identify_language(question, response)
     assert response.debug_info["original_language"] == language


### PR DESCRIPTION
Reviewer: @amiraliemami  

Estimate: 1hr

---

## Ticket

Fixes: [AAQ-281](https://idinsight.atlassian.net/browse/AAQ-281)

## Description, Motivation and Context

### Goal
To add simple multilingual support on the backend.

### Changes
1. When creating content, we now need to specify language
2. Based on detected language of the query, we do similarity search only within contents in the same language.
3. Language is optional on the backend. If there is no detected language we search across all content.
4. + LLM response now summarizes top N responses!

> [!WARNING]
> Some of the changes we made here, e.g. 4, we might want to merge to main as well. I can cherry-pick and raise another PR later.

## How has this been tested?
- Please try all the content management and question answering APIs on dev mode
- All unit tests should pass

## Checklist

Fill with `x` for completed. Delete any lines that are not relevant

- [ ] My code follows the style guidelines of this project
- [ ] I have reviewed my own code to ensure good quality
- [ ] I have tested the functionality of my code to ensure it works as intended
- [ ] I have resolved merge conflicts
- [ ] I have updated the automated tests (if applicable)
- [ ] I have updated the requirements (if applicable)
- [ ] I have updated the README file (if applicable)
- [ ] I have updated affected documentation (if applicable)


[AAQ-281]: https://idinsight.atlassian.net/browse/AAQ-281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ