### PR TITLE
[AAQ-286] Temporarily deploy eg demo branch to dev

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,9 +1,9 @@
-name: Deploy on push to main
+name: Deploy on push to eg-demo
 on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - eg-demo
 
 permissions:
   id-token: write # This is required for requesting the JWT


### PR DESCRIPTION
Reviewer: @sidravi1 @amiraliemami 
Estimate: 30min

---

## Ticket

Fixes: [AAQ-286](https://idinsight.atlassian.net/browse/AAQ-286)

## Description, Motivation and Context

Temporarily fix automatic deployment to dev to happen only on push to `eg-demo` branch
1. The dev auto-deploy workflow will only get triggered on push to `eg-demo`
2. `workflow_dispatch` option allows us to manually redeploy other branches, too.
3. Upon merging, I anticipate that
    1. No push to main `main` will trigger automatic deployment. 
    2. since it will be a merge to main, this workflow won't be triggered. So to initially deploy `eg-demo`, we will have to manually use the workflow dispatch option.

## How has this been tested?
Not tested 😅 Not sure how to test it!

## To-do AFTER merge

- [ ] Ensure this commit is merged to `eg-demo`

## Checklist

Fill with `x` for completed. Delete any lines that are not relevant

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [ ] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [ ] I have updated the automated tests (if applicable)
- [ ] I have updated the requirements (if applicable)
- [ ] I have updated the README file (if applicable)
- [ ] I have updated affected documentation (if applicable)


[AAQ-286]: https://idinsight.atlassian.net/browse/AAQ-286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ