### PR TITLE
Fix names of rails to make it clearer

### DIFF
--- a/core_backend/app/llm_call/check_output.py
+++ b/core_backend/app/llm_call/check_output.py
@@ -38,7 +38,7 @@ class AlignScoreData(TypedDict):
     claim: str
 
 
-def check_align_score(func: Callable) -> Callable:
+def check_align_score__after(func: Callable) -> Callable:
     """
     Check the alignment score
     """
@@ -102,6 +102,7 @@ async def _check_align_score(
         "method": ALIGN_SCORE_METHOD,
         "score": align_score.score,
         "reason": align_score.reason,
+        "claim": claim,
     }
 
     if align_score.score < float(ALIGN_SCORE_THRESHOLD):

--- a/core_backend/app/llm_call/parse_input.py
+++ b/core_backend/app/llm_call/parse_input.py
@@ -77,7 +77,12 @@ async def _classify_safety(
                 "safety_classification"
             ] = safety_classification.value
             error_response.debug_info["query_text"] = question.query_text
-            logger.info("SAFETY CHECK failed on query id: " + str(response.query_id))
+            logger.info(
+                (
+                    f"SAFETY CHECK failed on query id: {str(response.query_id)} "
+                    f"for query text: {question.query_text}"
+                )
+            )
             return question, error_response
         else:
             response.debug_info["safety_classification"] = safety_classification.value
@@ -253,5 +258,10 @@ async def _paraphrase_question(
             error_type=ErrorType.UNABLE_TO_PARAPHRASE,
         )
         response.state = ResultState.ERROR
-        logger.info("PARAPHRASE FAILED on query id: " + str(response.query_id))
+        logger.info(
+            (
+                f"PARAPHRASE FAILED on query id:  {str(response.query_id)} "
+                f"for query text: {question.query_text}"
+            )
+        )
         return question, error_response

--- a/core_backend/app/llm_call/parse_input.py
+++ b/core_backend/app/llm_call/parse_input.py
@@ -31,7 +31,7 @@ STANDARD_FAILURE_MESSAGE = (
 )
 
 
-def classify_safety(func: Callable) -> Callable:
+def classify_safety__before(func: Callable) -> Callable:
     """
     Decorator to classify the safety of the question.
     """
@@ -85,7 +85,7 @@ async def _classify_safety(
     return question, response
 
 
-def identify_language(func: Callable) -> Callable:
+def identify_language__before(func: Callable) -> Callable:
     """
     Decorator to identify the language of the question.
     """
@@ -128,7 +128,7 @@ async def _identify_language(
     return question, response
 
 
-def translate_question(func: Callable) -> Callable:
+def translate_question__before(func: Callable) -> Callable:
     """
     Decorator to translate the question.
     """
@@ -207,7 +207,7 @@ async def _translate_question(
     return question, response
 
 
-def paraphrase_question(func: Callable) -> Callable:
+def paraphrase_question__before(func: Callable) -> Callable:
     """
     Decorator to paraphrase the question.
     """

--- a/core_backend/app/routers/question_answer.py
+++ b/core_backend/app/routers/question_answer.py
@@ -24,10 +24,10 @@ from ..db.vector_db import (
 from ..llm_call.check_output import check_align_score__after
 from ..llm_call.llm_rag import get_llm_rag_answer
 from ..llm_call.parse_input import (
-    classify_safety,
-    identify_language,
-    paraphrase_question,
-    translate_question,
+    classify_safety__before,
+    identify_language__before,
+    paraphrase_question__before,
+    translate_question__before,
 )
 from ..schemas import (
     FeedbackBase,
@@ -70,10 +70,10 @@ async def llm_response(
 
 
 @check_align_score__after
-@identify_language
-@translate_question
-@paraphrase_question
-@classify_safety
+@identify_language__before
+@translate_question__before
+@paraphrase_question__before
+@classify_safety__before
 async def get_llm_answer(
     user_query_refined: UserQueryRefined,
     response: UserQueryResponse,
@@ -148,9 +148,9 @@ async def embeddings_search(
         return response
 
 
-@identify_language
-@translate_question
-@paraphrase_question
+@identify_language__before
+@translate_question__before
+@paraphrase_question__before
 async def get_semantic_matches(
     user_query_refined: UserQueryRefined,
     response: UserQueryResponse | UserQueryResponseError,

--- a/core_backend/app/routers/question_answer.py
+++ b/core_backend/app/routers/question_answer.py
@@ -21,7 +21,7 @@ from ..db.vector_db import (
     get_qdrant_client,
     get_similar_content_async,
 )
-from ..llm_call.check_output import check_align_score
+from ..llm_call.check_output import check_align_score__after
 from ..llm_call.llm_rag import get_llm_rag_answer
 from ..llm_call.parse_input import (
     classify_safety,
@@ -69,7 +69,7 @@ async def llm_response(
         return response
 
 
-@check_align_score
+@check_align_score__after
 @identify_language
 @translate_question
 @paraphrase_question


### PR DESCRIPTION
Reviewer: @suzinyou 

Estimate: 10 mins

---

## Ticket

N/A

## Description, Motivation and Context

Fixed decorator names to make it obvious that it runs code `__before` or `__after` the wrapped function.
Figuring out the order of decorators should be a lot easier.

Also improved logging for rails

Test still pass!

## Checklist

Fill with `x` for completed. Delete any lines that are not relevant

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have updated the automated tests (if applicable)
- [ ] I have updated the requirements (if applicable)
- [ ] I have updated the README file (if applicable)
- [ ] I have updated affected documentation (if applicable)
