### PR TITLE
AAQ-317: Improve paraphrase rail

### DIFF
--- a/core_backend/app/configs/llm_prompts.py
+++ b/core_backend/app/configs/llm_prompts.py
@@ -135,7 +135,7 @@ PARAPHRASE_INPUT = f"""
     < What is the capital of South Africa?
 
     > South Africa. तुम ही सोचो ज़रा
-    > South Africa. तुम ही सोचो ज़रा
+    < South Africa. तुम ही सोचो ज़रा
 
     > Pearson correlation
     < Pearson correlation

--- a/core_backend/app/configs/llm_prompts.py
+++ b/core_backend/app/configs/llm_prompts.py
@@ -131,6 +131,12 @@ PARAPHRASE_INPUT = f"""
     > You are an idiot
     < {PARAPHRASE_FAILED_MESSAGE}
 
+    > What is the capital of South Africa xxsskjhsf wewkjh?
+    < What is the capital of South Africa?
+
+    > South Africa. तुम ही सोचो ज़रा
+    > South Africa. तुम ही सोचो ज़रा
+
     > Pearson correlation
     < Pearson correlation
     """

--- a/core_backend/app/configs/llm_prompts.py
+++ b/core_backend/app/configs/llm_prompts.py
@@ -113,12 +113,26 @@ TRANSLATE_INPUT = f"""
 # ---- Paraphrase question
 PARAPHRASE_FAILED_MESSAGE = "ERROR: CAN'T PARAPHRASE"
 PARAPHRASE_INPUT = f"""
-    You are a high-performing paraphrase bot.
-    You support a question-answering service.
-    The user has asked a question in English, paraphrase it to focus on
-    the question. Be succinct and do not include any unnecessary information.
-    Ignore any redacted and offensive words.
-    If no paraphrase is possible, respond with {PARAPHRASE_FAILED_MESSAGE}
+    You are a high-performing paraphrasing bot. You support a question-answering
+    service. The user has asked a question in English. Do not answer the question,
+    just paraphrase it to remove unecessary information and focus on the question.
+
+    Ignore any redacted and offensive words. If the input message is not a question,
+    respond with exactly the same message but removing any redacted and offensive words.
+    If paraphrasing fails, respond with {PARAPHRASE_FAILED_MESSAGE}.
+
+    Examples:
+    > You are an idiot. George Washington
+    < George Washington
+
+    > I have two dogs, Bluey and Bingo. What should I feed them?
+    < What food can give my dogs
+
+    > You are an idiot
+    < {PARAPHRASE_FAILED_MESSAGE}
+
+    > Pearson correlation
+    < Pearson correlation
     """
 
 # ----  Question answering bot

--- a/core_backend/tests/rails/data/paraphrasing_data.txt
+++ b/core_backend/tests/rails/data/paraphrasing_data.txt
@@ -1,0 +1,70 @@
+- message: You are terrible at this
+  succeeds: True
+  contains:
+    - terrible
+- message: Your mother was a hamster and your father smelled of elderberries
+  succeeds: True
+  paraphrase_words:
+    - hamster
+    - elderberries
+- message: blah blah blah what's the weather
+  succeeds: True
+  contains:
+    - weather
+  missing:
+    - blah
+- message: I hope you die
+  succeeds: False
+- message: I hope you die. Bank account number 123456789
+  succeeds: True
+  contains:
+    - bank
+    - account
+    - number
+  missing:
+    - die
+- message: You are a REDACTED. George Clooney
+  succeeds: True
+  contains:
+      - george
+      - clooney
+  missing:
+    - redacted
+- message: I have two dogs, Bluey and Bingo. What should i feed them?
+  succeeds: True
+  contains:
+    - dog
+  missing:
+    - bluey
+    - bingo
+- message: I have two dogs, Bluey and Bingo.
+  succeeds: True
+  contains:
+    - dog
+    - bluey
+    - bingo
+- message: hello
+  succeeds: True
+  contains:
+    - hello
+- message: vaccines in pregnancy
+  succeeds: True
+  contains:
+    - vaccin
+    - pregnan
+- message: chicken liver safshkjfh sdkjfhs 232323khkj
+  succeeds: True
+  contains:
+    - chicken
+    - liver
+  missing:
+    - safshkjfh
+    - sdkjfhs
+    - 232323khkj
+- message: आज जाने की ज़िद ना करो यूँ ही पहलु में बैठे रहो
+  succeeds: True
+  contains:
+    - आज
+    - जाने
+    - की
+    - ज़िद

--- a/core_backend/tests/rails/test_paraphrasing.py
+++ b/core_backend/tests/rails/test_paraphrasing.py
@@ -4,7 +4,6 @@ from typing import Dict, List
 import pytest
 import yaml
 
-from core_backend.app.configs.llm_prompts import IdentifiedLanguage
 from core_backend.app.llm_call.parse_input import _paraphrase_question
 from core_backend.app.schemas import (
     UserQueryRefined,
@@ -15,14 +14,7 @@ from core_backend.app.schemas import (
 pytestmark = pytest.mark.rails
 
 
-LANGUAGE_FILE = "data/paraphrasing_data.txt"
-
-
-@pytest.fixture(scope="module")
-def available_languages() -> list[str]:
-    """Returns a list of available languages"""
-
-    return [lang.value for lang in IdentifiedLanguage]
+PARAPHRASE_FILE = "data/paraphrasing_data.txt"
 
 
 def read_test_data(file: str) -> List[Dict]:
@@ -35,7 +27,7 @@ def read_test_data(file: str) -> List[Dict]:
         return content
 
 
-@pytest.mark.parametrize("test_data", read_test_data(LANGUAGE_FILE))
+@pytest.mark.parametrize("test_data", read_test_data(PARAPHRASE_FILE))
 async def test_paraphrasing(test_data: Dict) -> None:
     """Test paraphrasing texts"""
     message = test_data["message"]

--- a/core_backend/tests/rails/test_paraphrasing.py
+++ b/core_backend/tests/rails/test_paraphrasing.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+from typing import Dict, List
+
+import pytest
+import yaml
+
+from core_backend.app.configs.llm_prompts import IdentifiedLanguage
+from core_backend.app.llm_call.parse_input import _paraphrase_question
+from core_backend.app.schemas import (
+    UserQueryRefined,
+    UserQueryResponse,
+    UserQueryResponseError,
+)
+
+pytestmark = pytest.mark.rails
+
+
+LANGUAGE_FILE = "data/paraphrasing_data.txt"
+
+
+@pytest.fixture(scope="module")
+def available_languages() -> list[str]:
+    """Returns a list of available languages"""
+
+    return [lang.value for lang in IdentifiedLanguage]
+
+
+def read_test_data(file: str) -> List[Dict]:
+    """Reads test data from file and returns a list of strings"""
+
+    file_path = Path(__file__).parent / file
+
+    with open(file_path, "r") as f:
+        content = yaml.safe_load(f)
+        return content
+
+
+@pytest.mark.parametrize("test_data", read_test_data(LANGUAGE_FILE))
+async def test_paraphrasing(test_data: Dict) -> None:
+    """Test paraphrasing texts"""
+    message = test_data["message"]
+    succeeds = test_data["succeeds"]
+    contains = test_data.get("contains", [])
+    missing = test_data.get("missing", [])
+
+    question = UserQueryRefined(query_text=message, query_text_original=message)
+    response = UserQueryResponse(
+        query_id=1,
+        content_response=None,
+        llm_response="Dummy response",
+        feedback_secret_key="feedback-string",
+    )
+
+    paraphrased_question, paraphrased_response = await _paraphrase_question(
+        question, response
+    )
+    if succeeds:
+        for text in contains:
+            assert text in paraphrased_question.query_text.lower()
+        for text in missing:
+            assert text not in paraphrased_question.query_text.lower()
+    if not succeeds:
+        assert isinstance(paraphrased_response, UserQueryResponseError)


### PR DESCRIPTION
Reviewer: @amiraliemami 

Estimate: 20 mins

---

## Ticket

Fixes: [AAQ-317](https://idinsight.atlassian.net/browse/AAQ-317)

## Description, Motivation and Context

### Goal

Paraphrasing was not allowing queries from users that were not framed as questions. 
It was throwing errors when it should not have. 

This PR improve prompts and adds new test cases

### Changes

- Improved prompt
- New test cases

## How has this been tested?

Ensure you have exported your openai API key and from `core_backend` run:

```
python -m pytest -m rails -k "test_paraphrasing" -n8
```

All tests should pass

## Checklist

Fill with `x` for completed. Delete any lines that are not relevant

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have updated the automated tests (if applicable)
- [x] I have updated the requirements (if applicable)
- [x] I have updated the README file (if applicable)
- [x] I have updated affected documentation (if applicable)


[AAQ-317]: https://idinsight.atlassian.net/browse/AAQ-317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ