### PR TITLE
[AAQ-320] return error if llm response fails

### DIFF
--- a/core_backend/app/configs/llm_prompts.py
+++ b/core_backend/app/configs/llm_prompts.py
@@ -122,19 +122,17 @@ PARAPHRASE_INPUT = f"""
     """
 
 # ----  Question answering bot
-
-ANSWER_QUESTION_PROMPT = """
-    You are a high-performing question answering bot.
-    You support a maternal and child health chatbot.
-
-    Answer the user query in natural language by rewording the
-    following FAQ found below. Address the question directly and do not
-    respond with anything that is outside of the context of the given FAQ.
-
-    If the FAQ doesn't seem to answer the question, respond with
-    'Sorry, no relevant information found.'
-
-    Found FAQ: {faq}"""
+ANSWER_QUESTION_ERROR_MESSAGE = "Sorry, no relevant information found."
+ANSWER_QUESTION_PROMPT = (
+    "You are a high-performing question answering bot.\n"
+    "Answer the user query in English using the information "
+    "provided in the reference text found below. "
+    "Address the question directly and do not respond with anything that is "
+    "outside of the context of the given reference text. "
+    "If the reference text doesn't seem to contain an answer the question, "
+    f"respond with '{ANSWER_QUESTION_ERROR_MESSAGE}'\n"
+    "FAQ found: {faq}"
+)
 
 
 class AlignmentScore(BaseModel):

--- a/core_backend/app/schemas.py
+++ b/core_backend/app/schemas.py
@@ -40,6 +40,7 @@ class ErrorType(str, Enum):
     UNABLE_TO_TRANSLATE = "unable_to_translate"
     UNABLE_TO_PARAPHRASE = "unable_to_paraphrase"
     ALIGNMENT_TOO_LOW = "alignment_too_low"
+    LLM_RESPONSE_FAILED = "llm_response_failed"
 
 
 class UserQueryRefined(UserQueryBase):


### PR DESCRIPTION
Reviewer: @amiraliemami 
Estimate:

---

## Ticket

Fixes: https://idinsight.atlassian.net/browse/AAQ-320

## Description, Motivation and Context

### Goal

If llm response generation fails, we should retrun UserQueryErrorResponse instance. Otherwise check AlignScore step gets triggered.

### Changes

## How has this been tested?

## To-do before merge

(Optional -- remove this section if not needed)

- [ ] Ensure PR #56 is merged

## Checklist

Fill with `x` for completed. Delete any lines that are not relevant

- [ ] My code follows the style guidelines of this project
- [ ] I have reviewed my own code to ensure good quality
- [ ] I have tested the functionality of my code to ensure it works as intended
- [ ] I have resolved merge conflicts
- [ ] I have updated the automated tests (if applicable)
- [ ] I have updated the requirements (if applicable)
- [ ] I have updated the README file (if applicable)
- [ ] I have updated affected documentation (if applicable)
