### PR TITLE
[AAQ-318][AAQ-319] Handle error responses in validation test

### DIFF
--- a/.github/workflows/retrieval-validation.yaml
+++ b/.github/workflows/retrieval-validation.yaml
@@ -33,10 +33,11 @@ jobs:
           python-version: "3.10"
 
       - name: Configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github_actions_dev
           role-session-name: github-actions
+          role-duration-seconds: 7200
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Install Python dependencies

--- a/core_backend/validation/conftest.py
+++ b/core_backend/validation/conftest.py
@@ -87,7 +87,7 @@ def patch_save_to_db(monkeysession: pytest.FixtureRequest) -> None:
     )
 
 
-# create command line arguments for pytestas as per https://stackoverflow.com/a/42145604/7664921
+# create command line arguments for pytest as per https://stackoverflow.com/a/42145604/7664921
 def pytest_addoption(parser: pytest.Parser) -> None:
     parser.addoption("--validation_data_path", type=str, help="Path to validation data")
     parser.addoption("--content_data_path", type=str, help="Path to content data")

--- a/core_backend/validation/conftest.py
+++ b/core_backend/validation/conftest.py
@@ -6,9 +6,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from core_backend.app import create_app
 from core_backend.app.configs.app_config import QDRANT_COLLECTION_NAME
-from core_backend.app.db.db_models import UserQueryDB, UserQueryResponseDB
+from core_backend.app.db.db_models import (
+    UserQueryDB,
+    UserQueryResponseDB,
+    UserQueryResponseErrorDB,
+)
 from core_backend.app.db.vector_db import get_qdrant_client
-from core_backend.app.schemas import UserQueryResponse
+from core_backend.app.schemas import UserQueryResponse, UserQueryResponseError
 
 
 @pytest.fixture(scope="session")
@@ -56,6 +60,19 @@ def patch_save_to_db(monkeysession: pytest.FixtureRequest) -> None:
             response_datetime_utc=datetime.utcnow(),
         )
 
+    async def mock_save_error_to_db(
+        asession: AsyncSession,
+        user_query_db: UserQueryDB,
+        error: UserQueryResponseError,
+    ) -> UserQueryResponseErrorDB:
+        return UserQueryResponseErrorDB(
+            query_id=user_query_db.query_id,
+            error_message=error.model_dump()["error_message"],
+            error_type=error.model_dump()["error_type"],
+            error_datetime_utc=datetime.utcnow(),
+            debug_info=error.model_dump()["debug_info"],
+        )
+
     monkeysession.setattr(
         "core_backend.app.routers.question_answer.save_user_query_to_db",
         mock_save_query_to_db,
@@ -64,9 +81,13 @@ def patch_save_to_db(monkeysession: pytest.FixtureRequest) -> None:
         "core_backend.app.routers.question_answer.save_query_response_to_db",
         mock_save_response_to_db,
     )
+    monkeysession.setattr(
+        "core_backend.app.routers.question_answer.save_query_response_error_to_db",
+        mock_save_error_to_db,
+    )
 
 
-# create command line arguments for pytestas per https://stackoverflow.com/a/42145604/7664921
+# create command line arguments for pytestas as per https://stackoverflow.com/a/42145604/7664921
 def pytest_addoption(parser: pytest.Parser) -> None:
     parser.addoption("--validation_data_path", type=str, help="Path to validation data")
     parser.addoption("--content_data_path", type=str, help="Path to content data")

--- a/core_backend/validation/validate_retrieval.py
+++ b/core_backend/validation/validate_retrieval.py
@@ -71,6 +71,7 @@ class TestRetrievalPerformance:
         if notification_topic is not None:
             message_dict = self._generate_message(
                 accuracies,
+                retrieval_failure_rate,
                 validation_data_path=validation_data_path,
                 validation_data_label_col=validation_data_label_col,
                 validation_data_question_col=validation_data_question_col,
@@ -234,6 +235,7 @@ class TestRetrievalPerformance:
     def _generate_message(
         self,
         accuracies: List[float],
+        retrieval_failure_rate: float,
         validation_data_path: str,
         validation_data_question_col: str,
         validation_data_label_col: str,
@@ -258,6 +260,7 @@ class TestRetrievalPerformance:
             f"      • Text column: {content_data_text_col}\n"
             f"      • Label column: {content_data_label_col}\n"
             f"• Embedding model: {EMBEDDING_MODEL}\n"
+            f"• Retrieval failure rate: {retrieval_failure_rate:.1%}\n"
             f"• Top N accuracies:\n" + self.format_accuracies(accuracies)
         )
 

--- a/docs/develop/validation.md
+++ b/docs/develop/validation.md
@@ -16,6 +16,7 @@ The test assumes the validation data contains a single label representing the be
 matching content, rather than a ranked list of all relevant content.
 
 An example validation data will look like
+
 |query|label|
 |--|--|
 |"How?"|0|
@@ -24,6 +25,7 @@ An example validation data will look like
 |"May I?"|2|
 
 An example content data will look like
+
 |content_text|label|
 |--|--|
 |"Here's how."|0|
@@ -72,7 +74,7 @@ An example content data will look like
    authentication steps you need to do, e.g. for AWS login).
     ```
     cd aaq-core
-    
+
     python -m pytest core_backend/validation/validate_retrieval.py \
         --validation_data_path <path> \
         --content_data_path <path> \


### PR DESCRIPTION
Reviewer: @lickem22 

Estimate: 1 hour

---

## Ticket

Fixes both https://idinsight.atlassian.net/browse/AAQ-318 and https://idinsight.atlassian.net/browse/AAQ-319

## Description, Motivation and Context

### Goal
A few PRs recently got merged that break the validation script (view links in JIRA for details)
This PR fixes them.

How come we let validation script break???
- Validation is kinda costly in terms of time and cost esp because of guardrails. 
- We run validation only when there's a push to main. This means if a PR breaks validation we won't know till it's merged to main. This problem is still there 😅  and I'll think of some way to circumvent this without running validation too often.

### Changes
1. With the new guardrails, validation takes longer than 1 hour. Increased github actions credentials to last 2 hours.
2. Monkeypatch function that saves error response to DB. We don't create relational DB connections in tests
3. Handle cases when retrieval fails.
4. Log how many examples retrieval failed on.

## How has this been tested?
You can run the [Retrieval Validation](https://github.com/IDinsight/aaq-core/actions/workflows/retrieval-validation.yaml) action on this branch using workflow dispatch

<img width="880" alt="image" src="https://github.com/IDinsight/aaq-core/assets/7042047/91a77446-4329-48e5-b89a-4c92e3dadaef">


## Checklist

Fill with `x` for completed. Delete any lines that are not relevant

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have updated the automated tests (if applicable)
- [ ] I have updated the requirements (if applicable)
- [ ] I have updated the README file (if applicable)
- [ ] I have updated affected documentation (if applicable)
