### PR TITLE
[Hotfix] Update ecs.tf nginx log group to also use project name

### DIFF
--- a/infrastructure/demo/main/ecs.tf
+++ b/infrastructure/demo/main/ecs.tf
@@ -344,7 +344,7 @@ resource "aws_cloudwatch_log_group" "vectordb" {
 }
 
 resource "aws_cloudwatch_log_group" "nginx" {
-  name = "/ecs/nginx-task-${var.environment}"
+  name = "/ecs/nginx-task-${var.project_name}-${var.environment}"
 
   tags = merge({ Name = "nginx-task-${var.project_name}-${var.environment}", Module = "Web" }, var.tags)
 }


### PR DESCRIPTION
Reviewer: @lickem22 

Estimate: 5 minutes

---

## Ticket

Hot fix

## Description, Motivation and Context

Include project name in log group name for nginx like backend and frontend

## How has this been tested?

Tested by destroying and recreating resources using Terraform


## Checklist

Fill with `x` for completed. Delete any lines that are not relevant

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [ ] I have updated the automated tests (if applicable)
- [ ] I have updated the requirements (if applicable)
- [ ] I have updated the README file (if applicable)
- [ ] I have updated affected documentation (if applicable)
