### PR TITLE
Update Typebot version to 2.23.0

### DIFF
--- a/chat_managers/typebot/deployment/docker-compose.yml
+++ b/chat_managers/typebot/deployment/docker-compose.yml
@@ -17,12 +17,12 @@ services:
       - typebot-builder
 
   typebot-viewer:
-    image: baptistearno/typebot-viewer:2.22.2
+    image: baptistearno/typebot-viewer:2.23.0
     restart: always
     env_file: .env
 
   typebot-builder:
-    image: baptistearno/typebot-builder:2.22.2
+    image: baptistearno/typebot-builder:2.23.0
     restart: always
     env_file: .env
     depends_on:


### PR DESCRIPTION
Reviewer: @suzinyou 

Estimate: 5mins

---

## Ticket

No ticket

## Description, Motivation and Context

Updates Typebot version to the latest, [2.23.0](https://github.com/baptisteArno/typebot.io/releases/tag/v2.23.0), adding bug fixes and notably ElevenLabs Text-to-Speech.

Test by running docker compose locally.
