### PR TITLE
[Hotfix] upgrade RDS version so that pgvector version = 0.6.0

### DIFF
--- a/infrastructure/demo/main/db.tf
+++ b/infrastructure/demo/main/db.tf
@@ -1,7 +1,7 @@
 data "aws_rds_engine_version" "postgres" {
   # The latest version of Postgres is used for the RDS instance.
   engine             = "postgres"
-  preferred_versions = ["15.3"]
+  preferred_versions = ["15.6"]
 }
 
 resource "aws_db_instance" "web_db" {


### PR DESCRIPTION
Reviewer: @amiraliemami 

Estimate: 10 min

---

## Ticket
No ticket

## Description, Motivation and Context

* HNSW only got added in pgvector 0.5.0+
* postgres RDS only supports pgvector 0.5.0+ from 15.4-R2 or higher
* we could upgrade to 16 but that seems to require additional terraform configuration (major version upgrade). Since this is a hotfix I'm just upgrading to highest 15 version!

You can view the Postgres version - pgvector version mapping for RDS on [this page](https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-extensions.html#postgresql-extensions-15x)


## How has this been tested?

- Tested terraform code by running terraform on a fork.
- Tested that 15.6 works with pgvector HNSW by manually upgrading DB instance and redeploying backend

## Checklist

Fill with `x` for completed. Delete any lines that are not relevant

- [ ] My code follows the style guidelines of this project
- [ ] I have reviewed my own code to ensure good quality
- [ ] I have tested the functionality of my code to ensure it works as intended
- [ ] I have resolved merge conflicts
- [ ] I have updated the automated tests (if applicable)
- [ ] I have updated the requirements (if applicable)
- [ ] I have updated the README file (if applicable)
- [ ] I have updated affected documentation (if applicable)
