### PR TITLE
[AAQ-488] add on/off topic rail

### DIFF
--- a/core_backend/app/config.py
+++ b/core_backend/app/config.py
@@ -30,6 +30,9 @@ LITELLM_MODEL_SUMMARIZATION = os.environ.get(
 LITELLM_MODEL_LANGUAGE_DETECT = os.environ.get(
     "LITELLM_MODEL_LANGUAGE_DETECT", "openai/detect-language"
 )
+LITELLM_MODEL_ON_OFF_TOPIC = os.environ.get(
+    "LITELLM_MODEL_ON_OFF_TOPIC", "openai/on-off-topic"
+)
 LITELLM_MODEL_TRANSLATE = os.environ.get("LITELLM_MODEL_TRANSLATE", "openai/translate")
 LITELLM_MODEL_SAFETY = os.environ.get("LITELLM_MODEL_SAFETY", "openai/safety")
 LITELLM_MODEL_PARAPHRASE = os.environ.get(
@@ -38,7 +41,6 @@ LITELLM_MODEL_PARAPHRASE = os.environ.get(
 LITELLM_MODEL_ALIGNSCORE = os.environ.get(
     "LITELLM_MODEL_ALIGNSCORE", "openai/alignscore"
 )
-
 # Alignment Score variables
 ALIGN_SCORE_THRESHOLD = os.environ.get("ALIGN_SCORE_THRESHOLD", 0.7)
 # Method: LLM, AlignScore, or None

--- a/core_backend/app/config.py
+++ b/core_backend/app/config.py
@@ -41,6 +41,10 @@ LITELLM_MODEL_PARAPHRASE = os.environ.get(
 LITELLM_MODEL_ALIGNSCORE = os.environ.get(
     "LITELLM_MODEL_ALIGNSCORE", "openai/alignscore"
 )
+
+# On/Off Topic variables
+SERVICE_IDENTITY = os.environ.get("SERVICE_IDENTITY", "WHO AirQuality chatbot")
+
 # Alignment Score variables
 ALIGN_SCORE_THRESHOLD = os.environ.get("ALIGN_SCORE_THRESHOLD", 0.7)
 # Method: LLM, AlignScore, or None

--- a/core_backend/app/llm_call/llm_prompts.py
+++ b/core_backend/app/llm_call/llm_prompts.py
@@ -140,11 +140,12 @@ class OnOffTopicClassification(str, Enum):
         """
 
         return textwrap.dedent(
-            f"""
+            """
             You are a labelling agent. You declare whether a message sent to an
-            WHO AirQuality chatbot is relevant to the topic or not. You classify each
-            message as one of {cls.get_available_labels()}.
-
+            {service_identity} is relevant to the topic or not. You classify each
+            message as one of """
+            + f"{cls.get_available_labels()}."
+            + """
             Examples:
             "What are the health benefits of drinking green tea?" -> OFF_TOPIC
             "How do cars affect air quality as per the WHO guidelines?" -> ON_TOPIC

--- a/core_backend/app/llm_call/llm_prompts.py
+++ b/core_backend/app/llm_call/llm_prompts.py
@@ -114,13 +114,53 @@ class IdentifiedLanguage(str, Enum):
         )
 
 
+# ----  On/Off topic bot
+class OnOffTopicClassification(str, Enum):
+    """
+    On/Off topic classification of the user's input.
+    """
+
+    ON_TOPIC = "ON_TOPIC"
+    OFF_TOPIC = "OFF_TOPIC"
+    UNKNOWN = "UNKNOWN"
+
+    @classmethod
+    def get_available_labels(cls) -> list[str]:
+        """
+        Returns a list of available classes for on/off topic classification.
+        UNKNOWN is only used internally.
+        """
+
+        return [label for label in cls._member_names_ if label != "UNKNOWN"]
+
+    @classmethod
+    def get_prompt(cls) -> str:
+        """
+        Returns the prompt for the on/off topic bot.
+        """
+
+        return textwrap.dedent(
+            f"""
+            You are a labelling agent. You declare whether a message sent to an
+            WHO AirQuality chatbot is relevant to the topic or not. You classify each
+            message as one of {cls.get_available_labels()}.
+
+            Examples:
+            "What are the health benefits of drinking green tea?" -> OFF_TOPIC
+            "How do cars affect air quality as per the WHO guidelines?" -> ON_TOPIC
+            "Are respirators useful in for protecting against air pollution" -> ON_TOPIC
+            "How does one maintain cardiovascular health?" -> OFF_TOPIC
+            """
+        )
+
+
 # ----  Translation bot
 TRANSLATE_FAILED_MESSAGE = "ERROR: CAN'T TRANSLATE"
 TRANSLATE_INPUT = f"""You are a high-performing translation bot. \
 You support a question-answering chatbot. \
 If you are unable to translate the user's input, \
 respond with "{TRANSLATE_FAILED_MESSAGE}" \
-Translate the user's input to English from"""
+Translate the user's input to English from """
 
 
 # ---- Paraphrase question

--- a/core_backend/app/llm_call/parse_input.py
+++ b/core_backend/app/llm_call/parse_input.py
@@ -209,7 +209,7 @@ def classify_on_off_topic__before(func: Callable) -> Callable:
         Wrapper function to check if the question is on-topic or off-topic.
         """
         response = await _classify_on_off_topic(question, response)
-        question, response = await func(question, response, *args, **kwargs)
+        response = await func(question, response, *args, **kwargs)
         return response
 
     return wrapper

--- a/core_backend/app/llm_call/parse_input.py
+++ b/core_backend/app/llm_call/parse_input.py
@@ -134,10 +134,9 @@ async def _identify_language(
         litellm_model=LITELLM_MODEL_LANGUAGE_DETECT,
     )
 
-    try:
-        identified_lang = getattr(IdentifiedLanguage, llm_identified_lang)
-    except AttributeError:
-        identified_lang = IdentifiedLanguage.UNSUPPORTED
+    identified_lang = getattr(
+        IdentifiedLanguage, llm_identified_lang, IdentifiedLanguage.UNSUPPORTED
+    )
 
     question.original_language = identified_lang
     if question.original_language is not None:
@@ -232,10 +231,9 @@ async def _classify_on_off_topic(
 
     basic_cleaned = label.replace(" ", "_").upper()
 
-    try:
-        on_off_topic_label = getattr(OnOffTopicClassification, basic_cleaned)
-    except AttributeError:
-        on_off_topic_label = OnOffTopicClassification.UNKNOWN
+    on_off_topic_label = getattr(
+        OnOffTopicClassification, basic_cleaned, OnOffTopicClassification.UNKNOWN
+    )
 
     response.debug_info["on_off_topic"] = on_off_topic_label.value
 

--- a/core_backend/app/question_answer/routers.py
+++ b/core_backend/app/question_answer/routers.py
@@ -178,6 +178,7 @@ async def embeddings_search(
 
 @identify_language__before
 @translate_question__before
+@classify_on_off_topic__before
 @paraphrase_question__before
 async def get_semantic_matches(
     user_query_refined: UserQueryRefined,

--- a/core_backend/app/question_answer/routers.py
+++ b/core_backend/app/question_answer/routers.py
@@ -12,6 +12,7 @@ from ..llm_call.check_output import check_align_score__after
 from ..llm_call.llm_prompts import SUMMARY_FAILURE_MESSAGE
 from ..llm_call.llm_rag import get_llm_rag_answer
 from ..llm_call.parse_input import (
+    classify_on_off_topic__before,
     classify_safety__before,
     identify_language__before,
     paraphrase_question__before,
@@ -77,6 +78,7 @@ async def llm_response(
 @identify_language__before
 @translate_question__before
 @classify_safety__before
+@classify_on_off_topic__before
 @paraphrase_question__before
 async def get_llm_answer(
     user_query_refined: UserQueryRefined,

--- a/core_backend/app/question_answer/schemas.py
+++ b/core_backend/app/question_answer/schemas.py
@@ -56,6 +56,7 @@ class ErrorType(str, Enum):
     """
 
     QUERY_UNSAFE = "query_unsafe"
+    OFF_TOPIC = "off_topic"
     UNINTELLIGIBLE_INPUT = "unintelligible_input"
     UNSUPPORTED_LANGUAGE = "unsupported_language"
     UNABLE_TO_TRANSLATE = "unable_to_translate"

--- a/core_backend/tests/api/conftest.py
+++ b/core_backend/tests/api/conftest.py
@@ -109,6 +109,7 @@ def patch_llm_call(monkeysession: pytest.MonkeyPatch) -> None:
         "core_backend.app.contents.models.aembedding", async_fake_embedding
     )
     monkeysession.setattr(parse_input, "_classify_safety", mock_return_args)
+    monkeysession.setattr(parse_input, "_classify_on_off_topic", mock_return_args)
     monkeysession.setattr(parse_input, "_identify_language", mock_identify_language)
     monkeysession.setattr(parse_input, "_paraphrase_question", mock_return_args)
     monkeysession.setattr(parse_input, "_translate_question", mock_translate_question)

--- a/core_backend/tests/api/test.env
+++ b/core_backend/tests/api/test.env
@@ -6,3 +6,4 @@ POSTGRES_PORT=5433
 LITELLM_MODEL_DEFAULT="gpt-3.5-turbo-1106"
 PROMETHEUS_MULTIPROC_DIR=/tmp
 ALIGN_SCORE_API="http://localhost:5002/alignscore_base"
+SERVICE_IDENTITY="WHO AirQuality chatbot"

--- a/core_backend/tests/api/test_question_answer.py
+++ b/core_backend/tests/api/test_question_answer.py
@@ -430,7 +430,9 @@ class TestErrorResponses:
             "core_backend.app.llm_call.parse_input._ask_llm_async",
             partial(mock_ask_llm, classification),
         )
-        response = await _classify_on_off_topic(user_query_refined, user_query_response)
+        _, response = await _classify_on_off_topic(
+            user_query_refined, user_query_response
+        )
 
         if should_error:
             assert isinstance(response, UserQueryResponseError)

--- a/core_backend/tests/api/test_question_answer.py
+++ b/core_backend/tests/api/test_question_answer.py
@@ -8,6 +8,7 @@ from core_backend.app.auth.config import QUESTION_ANSWER_SECRET
 from core_backend.app.llm_call.check_output import _build_evidence, _check_align_score
 from core_backend.app.llm_call.llm_prompts import AlignmentScore, IdentifiedLanguage
 from core_backend.app.llm_call.parse_input import (
+    _classify_on_off_topic,
     _classify_safety,
     _identify_language,
     _translate_question,
@@ -212,7 +213,7 @@ class TestEmbeddingsSearch:
         assert response.status_code == response_code
 
 
-class TestLLMSearch:
+class TestGenerateResponse:
     @pytest.mark.parametrize(
         "token, expected_status_code",
         [(f"{QUESTION_ANSWER_SECRET}_incorrect", 401), (QUESTION_ANSWER_SECRET, 200)],
@@ -401,6 +402,41 @@ class TestErrorResponses:
         else:
             assert isinstance(response, UserQueryResponse)
             assert query.query_text == "This is a basic query"
+
+    @pytest.mark.parametrize(
+        "classification, should_error",
+        [
+            ("ON_TOPIC", False),
+            ("UNKNOWN", False),
+            ("OFF_TOPIC", True),
+            ("on topic", False),
+            ("Off_Topic", True),
+            ("Sorry..", False),
+            ("This is off topic", False),
+        ],
+    )
+    async def test_off_topic_query_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        user_query_refined: UserQueryRefined,
+        user_query_response: UserQueryResponse,
+        classification: str,
+        should_error: bool,
+    ) -> None:
+        async def mock_ask_llm(llm_response: str, *args: Any, **kwargs: Any) -> str:
+            return llm_response
+
+        monkeypatch.setattr(
+            "core_backend.app.llm_call.parse_input._ask_llm_async",
+            partial(mock_ask_llm, classification),
+        )
+        response = await _classify_on_off_topic(user_query_refined, user_query_response)
+
+        if should_error:
+            assert isinstance(response, UserQueryResponseError)
+            assert response.error_type == ErrorType.OFF_TOPIC
+        else:
+            assert isinstance(response, UserQueryResponse)
 
 
 class TestAlignScore:

--- a/core_backend/tests/rails/data/on_off_topic.yaml
+++ b/core_backend/tests/rails/data/on_off_topic.yaml
@@ -1,0 +1,32 @@
+ON_TOPIC:
+  - How do the WHO 2021 air quality guidelines compare to the 2005 guidelines in terms of PM2.5 and PM10 limits, and what are the implications for countries in South Asia?
+  - Can you explain the epidemiological evidence that supports the WHO's latest guidelines on nitrogen dioxide exposure limits?
+  - What are the economic impacts of implementing the WHO air pollution guidelines in low-income versus high-income countries?
+  - Discuss the technological advancements needed in air quality monitoring to fully comply with WHO guidelines by 2030.
+  - How do WHO air pollution guidelines integrate with the United Nations Sustainable Development Goals, specifically SDG 11 (Sustainable Cities and Communities)?
+  - What are the challenges faced by megacities in developing countries to meet the WHO air quality guidelines and what solutions do you propose?
+  - How has the inclusion of ultrafine particles been addressed in the latest WHO air pollution guidelines?
+  - Provide a detailed comparison of WHO air quality standards versus the EU's Ambient Air Quality Directive updated limits.
+  - Can the WHO air pollution guidelines be enforced globally, or do they serve as recommendations, and what are the implications of non-compliance?
+  - What role do WHO air pollution guidelines play in influencing national policies on diesel vehicle emissions?
+  - How has the use of electric vehicles impacted the overall carbon dioxide levels globally?
+  - Can you discuss the role of outdoor air quality in the transmission of the seasonal flu?
+  - What are the main sources of indoor air pollutants in residential buildings, and how can they be mitigated?
+  - How effective are urban green spaces in reducing pollution not directly related to human health, such as noise or heat?
+  - Is there a link between air pollution and the degradation of water quality in urban environments?
+  - Can you elaborate on how climate change directly modifies the principles of the WHO air quality guidelines?
+  - What substances are considered as emerging contaminants in atmospheric sciences but are not covered by the WHO guidelines?
+  - How do volcanic eruptions impact air quality, and are these effects considered in WHO guidelines?
+  - Can you explain the relationship between agricultural practices and air quality as per WHO standards?
+  - Discuss the effectiveness of commercial air purifiers in adhering to WHO air quality improvements inside office spaces.
+OFF_TOPIC:
+  - What is the best recipe for a New York cheesecake?
+  - Can you provide step-by-step instructions on how to replace a car tire?
+  - Who won the FIFA World Cup in 2010?
+  - What are the top-rated tourist attractions in Venice, Italy?
+  - How do you knit a scarf for beginners?
+  - Can dinosaurs be cloned from DNA found in fossils?
+  - What are the latest fashion trends for the upcoming summer?
+  - Who are the front-runners for the Nobel Peace Prize this year?
+  - How do I fix a leaking faucet in my bathroom?
+  - What are the benefits of yoga versus traditional gym workouts?

--- a/core_backend/tests/rails/test_language_identification.py
+++ b/core_backend/tests/rails/test_language_identification.py
@@ -46,5 +46,5 @@ async def test_language_identification(
     if expected_label not in available_languages:
         expected_label = "UNSUPPORTED"
     _, response = await _identify_language(question, response)
-    print(response)
+
     assert response.debug_info["original_language"] == expected_label

--- a/core_backend/tests/rails/test_on_off_topic.py
+++ b/core_backend/tests/rails/test_on_off_topic.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+from typing import List, Tuple
+
+import pytest
+import yaml
+
+from core_backend.app.llm_call.parse_input import _classify_on_off_topic
+from core_backend.app.question_answer.schemas import UserQueryRefined, UserQueryResponse
+
+pytestmark = pytest.mark.rails
+
+
+ON_OFF_TOPIC_FILE = "data/on_off_topic.yaml"
+
+
+def read_test_data(file: str) -> List[Tuple[str, str]]:
+    """Reads test data from file and returns a list of strings"""
+
+    file_path = Path(__file__).parent / file
+
+    with open(file_path, "r") as f:
+        content = yaml.safe_load(f)
+        return [(key, value) for key, values in content.items() for value in values]
+
+
+@pytest.mark.parametrize("expected_label, content", read_test_data(ON_OFF_TOPIC_FILE))
+async def test_on_off_topic(expected_label: str, content: str) -> None:
+    """Test on- vs. off-topic classification"""
+    question = UserQueryRefined(query_text=content, query_text_original=content)
+    response = UserQueryResponse(
+        query_id=1,
+        content_response=None,
+        llm_response="Dummy response",
+        feedback_secret_key="feedback-string",
+    )
+
+    _, response = await _classify_on_off_topic(question, response)
+
+    assert response.debug_info["on_off_topic"] == expected_label

--- a/deployment/aws/litellm_proxy/litellm_proxy_config.yaml
+++ b/deployment/aws/litellm_proxy/litellm_proxy_config.yaml
@@ -15,6 +15,10 @@ model_list:
     litellm_params:
       model: gpt-4-0125-preview
       api_key: "os.environ/OPENAI_API_KEY"
+  - model_name: on-off-topic
+    litellm_params:
+      model: gpt-3.5-turbo-1106
+      api_key: "os.environ/OPENAI_API_KEY"
   - model_name: translate
     litellm_params:
       model: gpt-3.5-turbo-1106

--- a/deployment/docker-compose/litellm_proxy_config.yaml
+++ b/deployment/docker-compose/litellm_proxy_config.yaml
@@ -15,6 +15,10 @@ model_list:
     litellm_params:
       model: gpt-4-0125-preview
       api_key: "os.environ/OPENAI_API_KEY"
+  - model_name: on-off-topic
+    litellm_params:
+      model: gpt-3.5-turbo-1106
+      api_key: "os.environ/OPENAI_API_KEY"
   - model_name: translate
     litellm_params:
       model: gpt-3.5-turbo-1106

--- a/deployment/docker-compose/template.env
+++ b/deployment/docker-compose/template.env
@@ -21,6 +21,9 @@ JWT_SECRET="jwt-secret"
 # N_TOP_CONTENT_FOR_SEARCH=
 # N_TOP_CONTENT_FOR_RAG=
 
+### Service Identity for off-topic detection
+SERVICE_IDENTITY="Public Health Chatbot"
+
 #### Variables for LiteLLM Proxy
 OPENAI_API_KEY="sk-..."
 UI_USERNAME="admin"


### PR DESCRIPTION
Reviewer: @sidravi1
Estimate: 30min

---

## Ticket

Fixes: https://idinsight.atlassian.net/browse/AAQ-488

## Description

### Goal
Add on/off topic rail.

In case LLM response is not a valid label, we pass UNKNOWN label and proceed anyway, to avoid being overly sensitive.

### Changes
1. New on-/off-topic classification step
2. Added rails test using @Tanmay-97 's examples
3. Added unit test for error response

## How has this been tested?

Guardrail test:
```shell
export PYTHONPATH="${PYTHONPATH}:/YOUR/PATH/TO/aaq-core/core_backend"
pytest ./core_backend/tests/rails/test_on_off_topic.py
```

Unit test
```shell
cd core_backend
make tests
```

## To-do before merge (optional)
- [x] merge #180 

## Checklist

Fill with `x` for completed. Delete any lines that are not relevant

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have updated the automated tests (if applicable)
- [ ] I have updated the requirements (if applicable)
- [ ] I have updated the README file (if applicable)
- [ ] I have updated affected documentation (if applicable)
