### PR TITLE
Add user pytests

### DIFF
--- a/core_backend/app/urgency_rules/routers.py
+++ b/core_backend/app/urgency_rules/routers.py
@@ -67,6 +67,13 @@ async def delete_urgency_rule(
     Delete a single urgency rule by id
     """
 
+    urgency_rule_db = await get_urgency_rule_by_id_from_db(
+        user_id=user_db.user_id, urgency_rule_id=urgency_rule_id, asession=asession
+    )
+    if not urgency_rule_db:
+        raise HTTPException(
+            status_code=404, detail=f"Urgency Rule id `{urgency_rule_id}` not found"
+        )
     await delete_urgency_rule_from_db(
         user_id=user_db.user_id, urgency_rule_id=urgency_rule_id, asession=asession
     )

--- a/core_backend/tests/api/__init__.py
+++ b/core_backend/tests/api/__init__.py
@@ -1,3 +1,3 @@
 import pytest
 
-pytestmark = pytest.mark.asyncio(scope="package")
+pytestmark = pytest.mark.asyncio()

--- a/core_backend/tests/api/conftest.py
+++ b/core_backend/tests/api/conftest.py
@@ -44,12 +44,12 @@ CompletionChoice = namedtuple("CompletionChoice", "message")
 CompletionMessage = namedtuple("CompletionMessage", "content")
 
 
-TEST_USER_ID = 123
+TEST_USER_ID = 1
 TEST_USERNAME = "test_username"
 TEST_PASSWORD = "test_password"
 TEST_USER_RETRIEVAL_KEY = "test_retrieval_key"
 
-TEST_USER_ID_2 = "test_user_id_2"
+TEST_USER_ID_2 = 2
 TEST_USERNAME_2 = "test_username_2"
 TEST_PASSWORD_2 = "test_password_2"
 TEST_USER_RETRIEVAL_KEY_2 = "test_retrieval_key_2"

--- a/core_backend/tests/api/conftest.py
+++ b/core_backend/tests/api/conftest.py
@@ -8,6 +8,8 @@ import httpx
 import numpy as np
 import pytest
 from fastapi.testclient import TestClient
+from pytest import Item
+from pytest_asyncio import is_async_test
 from sqlalchemy.orm import Session
 
 from core_backend.app import create_app
@@ -51,6 +53,13 @@ TEST_USER_ID_2 = "test_user_id_2"
 TEST_USERNAME_2 = "test_username_2"
 TEST_PASSWORD_2 = "test_password_2"
 TEST_USER_RETRIEVAL_KEY_2 = "test_retrieval_key_2"
+
+
+def pytest_collection_modifyitems(items: List[Item]) -> None:
+    pytest_asyncio_tests = (item for item in items if is_async_test(item))
+    session_scope_marker = pytest.mark.asyncio(scope="session")
+    for async_test in pytest_asyncio_tests:
+        async_test.add_marker(session_scope_marker, append=False)
 
 
 @pytest.fixture(scope="session")

--- a/core_backend/tests/api/conftest.py
+++ b/core_backend/tests/api/conftest.py
@@ -47,6 +47,11 @@ TEST_USERNAME = "test_username"
 TEST_PASSWORD = "test_password"
 TEST_USER_RETRIEVAL_KEY = "test_retrieval_key"
 
+TEST_USER_ID_2 = "test_user_id_2"
+TEST_USERNAME_2 = "test_username_2"
+TEST_PASSWORD_2 = "test_password_2"
+TEST_USER_RETRIEVAL_KEY_2 = "test_retrieval_key_2"
+
 
 @pytest.fixture(scope="session")
 def db_session() -> Generator[Session, None, None]:
@@ -63,8 +68,7 @@ def db_session() -> Generator[Session, None, None]:
 
 @pytest.fixture(scope="session", autouse=True)
 def user(client: TestClient, db_session: Session) -> None:
-
-    user_db = UserDB(
+    user1_db = UserDB(
         user_id=TEST_USER_ID,
         username=TEST_USERNAME,
         hashed_password=get_password_salted_hash(TEST_PASSWORD),
@@ -72,7 +76,16 @@ def user(client: TestClient, db_session: Session) -> None:
         created_datetime_utc=datetime.utcnow(),
         updated_datetime_utc=datetime.utcnow(),
     )
-    db_session.add(user_db)
+    user2_db = UserDB(
+        user_id=TEST_USER_ID_2,
+        username=TEST_USERNAME_2,
+        hashed_password=get_key_hash(TEST_PASSWORD_2),
+        hashed_retrieval_key=get_key_hash(TEST_USER_RETRIEVAL_KEY_2),
+        created_datetime_utc=datetime.utcnow(),
+        updated_datetime_utc=datetime.utcnow(),
+    )
+    db_session.add(user1_db)
+    db_session.add(user2_db)
     db_session.commit()
 
 
@@ -266,6 +279,14 @@ def fullaccess_token() -> str:
     Returns a token with full access
     """
     return create_access_token(TEST_USERNAME)
+
+
+@pytest.fixture(scope="session")
+def fullaccess_token_user2() -> str:
+    """
+    Returns a token with full access
+    """
+    return create_access_token(TEST_USERNAME_2)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/core_backend/tests/api/test_key_management.py
+++ b/core_backend/tests/api/test_key_management.py
@@ -1,0 +1,17 @@
+from fastapi.testclient import TestClient
+
+from core_backend.tests.api.conftest import TEST_USER_RETRIEVAL_KEY
+
+
+class TestKeyManagement:
+    async def test_get_new_retrieval_key(
+        self, client: TestClient, fullaccess_token: str
+    ) -> None:
+        response = client.put(
+            "/key",
+            headers={"Authorization": f"Bearer {fullaccess_token}"},
+        )
+
+        assert response.status_code == 200
+        json_response = response.json()
+        assert json_response["new_retrieval_key"] != TEST_USER_RETRIEVAL_KEY

--- a/core_backend/tests/api/test_key_management.py
+++ b/core_backend/tests/api/test_key_management.py
@@ -1,17 +1,17 @@
 from fastapi.testclient import TestClient
 
-from core_backend.tests.api.conftest import TEST_USER_RETRIEVAL_KEY
+from core_backend.tests.api.conftest import TEST_USER_RETRIEVAL_KEY_2
 
 
 class TestKeyManagement:
     async def test_get_new_retrieval_key(
-        self, client: TestClient, fullaccess_token: str
+        self, client: TestClient, fullaccess_token_user2: str
     ) -> None:
         response = client.put(
             "/key",
-            headers={"Authorization": f"Bearer {fullaccess_token}"},
+            headers={"Authorization": f"Bearer {fullaccess_token_user2}"},
         )
 
         assert response.status_code == 200
         json_response = response.json()
-        assert json_response["new_retrieval_key"] != TEST_USER_RETRIEVAL_KEY
+        assert json_response["new_retrieval_key"] != TEST_USER_RETRIEVAL_KEY_2

--- a/core_backend/tests/api/test_manage_content.py
+++ b/core_backend/tests/api/test_manage_content.py
@@ -159,6 +159,8 @@ class TestManageContent:
         )
         assert response.status_code == 200
 
+
+class TestMultUserManageContent:
     @pytest.mark.parametrize(
         "content_title, content_text, content_metadata",
         [("title 3", "test content 3", {})],

--- a/core_backend/tests/api/test_manage_content.py
+++ b/core_backend/tests/api/test_manage_content.py
@@ -161,68 +161,47 @@ class TestManageContent:
 
 
 class TestMultUserManageContent:
-    @pytest.mark.parametrize(
-        "content_title, content_text, content_metadata",
-        [("title 3", "test content 3", {})],
-    )
-    async def test_content_access_overlap(
+    async def test_user2_get_user1_content(
         self,
         client: TestClient,
-        content_title: str,
-        content_text: str,
-        fullaccess_token: str,
+        existing_content_id: str,
         fullaccess_token_user2: str,
-        content_metadata: Dict[Any, Any],
     ) -> None:
-        # make content as user1
-        response = client.post(
-            "/content",
-            headers={"Authorization": f"Bearer {fullaccess_token}"},
-            json={
-                "content_title": content_title,
-                "content_text": content_text,
-                "content_language": "ENGLISH",
-                "content_metadata": content_metadata,
-            },
-        )
-        assert response.status_code == 200
-        json_response = response.json()
-        assert json_response["content_metadata"] == content_metadata
-        assert "content_id" in json_response
-
-        # try to fetch content as user2
         response = client.get(
-            f"/content/{json_response['content_id']}",
+            f"/content/{existing_content_id}",
             headers={"Authorization": f"Bearer {fullaccess_token_user2}"},
         )
         assert response.status_code == 404
 
-        # try to edit content as user2
+    async def test_user2_edit_user1_content(
+        self,
+        client: TestClient,
+        existing_content_id: str,
+        fullaccess_token_user2: str,
+    ) -> None:
         response = client.put(
-            f"/content/{json_response['content_id']}",
+            f"/content/{existing_content_id}",
             headers={"Authorization": f"Bearer {fullaccess_token_user2}"},
             json={
-                "content_title": content_title,
-                "content_text": content_text,
+                "content_title": "user2 title 3",
+                "content_text": "user2 test content 3",
                 "content_language": "ENGLISH",
-                "content_metadata": content_metadata,
+                "content_metadata": {},
             },
         )
         assert response.status_code == 404
 
-        # try to delete content as user2
+    async def test_user2_delete_user1_content(
+        self,
+        client: TestClient,
+        existing_content_id: str,
+        fullaccess_token_user2: str,
+    ) -> None:
         response = client.delete(
-            f"/content/{json_response['content_id']}",
+            f"/content/{existing_content_id}",
             headers={"Authorization": f"Bearer {fullaccess_token_user2}"},
         )
         assert response.status_code == 404
-
-        # delete content as user1
-        response = client.delete(
-            f"/content/{json_response['content_id']}",
-            headers={"Authorization": f"Bearer {fullaccess_token}"},
-        )
-        assert response.status_code == 200
 
 
 async def test_convert_record_to_schema() -> None:

--- a/core_backend/tests/api/test_manage_ud_rules.py
+++ b/core_backend/tests/api/test_manage_ud_rules.py
@@ -144,6 +144,8 @@ class TestManageUDRules:
         )
         assert response.status_code == 200
 
+
+class TestMultUserManageUDRules:
     @pytest.mark.parametrize(
         "urgency_rule_text, urgency_rule_metadata",
         [("test rule 5", {})],

--- a/core_backend/tests/api/test_manage_ud_rules.py
+++ b/core_backend/tests/api/test_manage_ud_rules.py
@@ -146,62 +146,45 @@ class TestManageUDRules:
 
 
 class TestMultUserManageUDRules:
-    @pytest.mark.parametrize(
-        "urgency_rule_text, urgency_rule_metadata",
-        [("test rule 5", {})],
-    )
-    async def test_ud_rules_access_overlap(
+    async def user2_get_user1_UDrule(
         self,
         client: TestClient,
-        urgency_rule_text: str,
-        fullaccess_token: str,
+        existing_rule_id: str,
         fullaccess_token_user2: str,
-        urgency_rule_metadata: Dict[Any, Any],
     ) -> None:
-        # make rules as user1
-        response = client.post(
-            "/urgency-rules",
-            headers={"Authorization": f"Bearer {fullaccess_token}"},
-            json={
-                "urgency_rule_text": urgency_rule_text,
-                "urgency_rule_metadata": urgency_rule_metadata,
-            },
-        )
-        assert response.status_code == 200
-        json_response = response.json()
-        assert "urgency_rule_id" in json_response
-
-        # try to fetch rules as user2
         response = client.get(
-            f"/urgency-rules/{json_response['urgency_rule_id']}",
+            f"/urgency-rules/{existing_rule_id}",
             headers={"Authorization": f"Bearer {fullaccess_token_user2}"},
         )
         assert response.status_code == 404
 
-        # try to edit rules as user2
+    async def user2_edit_user1_UDrule(
+        self,
+        client: TestClient,
+        existing_rule_id: str,
+        fullaccess_token_user2: str,
+    ) -> None:
         response = client.put(
-            f"/urgency-rules/{json_response['urgency_rule_id']}",
+            f"/urgency-rules/{existing_rule_id}",
             headers={"Authorization": f"Bearer {fullaccess_token_user2}"},
             json={
-                "urgency_rule_text": urgency_rule_text,
-                "urgency_rule_metadata": urgency_rule_metadata,
+                "urgency_rule_text": "user2 rule",
+                "urgency_rule_metadata": {},
             },
         )
         assert response.status_code == 404
 
-        # try to delete rules as user2
+    async def user2_delete_user1_UDrule(
+        self,
+        client: TestClient,
+        existing_rule_id: str,
+        fullaccess_token_user2: str,
+    ) -> None:
         response = client.delete(
-            f"/urgency-rules/{json_response['urgency_rule_id']}",
+            f"/urgency-rules/{existing_rule_id}",
             headers={"Authorization": f"Bearer {fullaccess_token_user2}"},
         )
         assert response.status_code == 404
-
-        # delete rules as user1
-        response = client.delete(
-            f"/urgency-rules/{json_response['urgency_rule_id']}",
-            headers={"Authorization": f"Bearer {fullaccess_token}"},
-        )
-        assert response.status_code == 200
 
 
 async def test_convert_record_to_schema() -> None:

--- a/core_backend/tests/api/test_question_answer.py
+++ b/core_backend/tests/api/test_question_answer.py
@@ -21,13 +21,20 @@ from core_backend.app.question_answer.schemas import (
     QuerySearchResult,
     ResultState,
 )
-from core_backend.tests.api.conftest import TEST_USER_RETRIEVAL_KEY
+from core_backend.tests.api.conftest import (
+    TEST_USER_RETRIEVAL_KEY,
+    TEST_USER_RETRIEVAL_KEY_2,
+)
 
 
 class TestEmbeddingsSearch:
     @pytest.mark.parametrize(
         "token, expected_status_code",
-        [(f"{TEST_USER_RETRIEVAL_KEY}_incorrect", 401), (TEST_USER_RETRIEVAL_KEY, 200)],
+        [
+            (f"{TEST_USER_RETRIEVAL_KEY}_incorrect", 401),
+            (TEST_USER_RETRIEVAL_KEY_2, 401),
+            (TEST_USER_RETRIEVAL_KEY, 200),
+        ],
     )
     async def test_content_response(
         self,
@@ -63,8 +70,10 @@ class TestEmbeddingsSearch:
         [
             (f"{TEST_USER_RETRIEVAL_KEY}_incorrect", 401, "/response-feedback"),
             (TEST_USER_RETRIEVAL_KEY, 200, "/response-feedback"),
+            (TEST_USER_RETRIEVAL_KEY_2, 401, "/response-feedback"),
             (f"{TEST_USER_RETRIEVAL_KEY}_incorrect", 401, "/content-feedback"),
             (TEST_USER_RETRIEVAL_KEY, 200, "/content-feedback"),
+            (TEST_USER_RETRIEVAL_KEY_2, 401, "/content-feedback"),
         ],
     )
     async def test_response_feedback_correct_token(
@@ -216,7 +225,11 @@ class TestEmbeddingsSearch:
 class TestGenerateResponse:
     @pytest.mark.parametrize(
         "token, expected_status_code",
-        [(f"{TEST_USER_RETRIEVAL_KEY}_incorrect", 401), (TEST_USER_RETRIEVAL_KEY, 200)],
+        [
+            (f"{TEST_USER_RETRIEVAL_KEY}_incorrect", 401),
+            (TEST_USER_RETRIEVAL_KEY_2, 401),
+            (TEST_USER_RETRIEVAL_KEY, 200),
+        ],
     )
     async def test_llm_response(
         self,

--- a/core_backend/tests/api/test_question_dashboard.py
+++ b/core_backend/tests/api/test_question_dashboard.py
@@ -4,7 +4,7 @@ from fastapi.testclient import TestClient
 from .conftest import mock_dashboard_stats
 
 
-def test_retrieve_question_dashboard(
+async def test_retrieve_question_dashboard(
     client: TestClient,
     fullaccess_token: str,
     monkeypatch: pytest.MonkeyPatch,

--- a/core_backend/tests/api/test_urgency_detect.py
+++ b/core_backend/tests/api/test_urgency_detect.py
@@ -39,7 +39,7 @@ class TestUrgencyDetectionToken:
 
 
 class TestUrgencyClassifiers:
-    @pytest.fixture(scope="class")
+    @pytest.fixture(scope="function")
     async def asession(self) -> AsyncGenerator[AsyncSession, None]:
         async for session in get_async_session():
             yield session

--- a/core_backend/tests/api/test_urgency_detect.py
+++ b/core_backend/tests/api/test_urgency_detect.py
@@ -7,13 +7,21 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from core_backend.app.database import get_async_session
 from core_backend.app.urgency_detection.routers import ALL_URGENCY_CLASSIFIERS
 from core_backend.app.urgency_detection.schemas import UrgencyQuery, UrgencyResponse
-from core_backend.tests.api.conftest import TEST_USER_ID, TEST_USER_RETRIEVAL_KEY
+from core_backend.tests.api.conftest import (
+    TEST_USER_ID,
+    TEST_USER_RETRIEVAL_KEY,
+    TEST_USER_RETRIEVAL_KEY_2,
+)
 
 
 class TestUrgencyDetectionToken:
     @pytest.mark.parametrize(
         "token, expected_status_code",
-        [(f"{TEST_USER_RETRIEVAL_KEY}_incorrect", 401), (TEST_USER_RETRIEVAL_KEY, 200)],
+        [
+            (f"{TEST_USER_RETRIEVAL_KEY}_incorrect", 401),
+            (TEST_USER_RETRIEVAL_KEY_2, 401),
+            (TEST_USER_RETRIEVAL_KEY, 200),
+        ],
     )
     async def test_ud_response(
         self,

--- a/core_backend/tests/api/test_users.py
+++ b/core_backend/tests/api/test_users.py
@@ -32,13 +32,13 @@ class TestUsers:
 
     async def test_save_user_to_db(self, asession: AsyncSession) -> None:
         user = UserCreate(
-            user_id="test_user_id_2",
-            username="test_username_2",
-            password="test_password_2",
-            retrieval_key="test_retrieval_key_2",
+            user_id="test_user_id_3",
+            username="test_username_3",
+            password="test_password_3",
+            retrieval_key="test_retrieval_key_3",
         )
         saved_user = await save_user_to_db(user, asession)
-        assert saved_user.username == "test_username_2"
+        assert saved_user.username == "test_username_3"
 
     async def test_save_user_to_db_existing_user(self, asession: AsyncSession) -> None:
         user = UserCreate(
@@ -68,14 +68,14 @@ class TestUsers:
 
     async def test_update_user_retrieval_key(self, asession: AsyncSession) -> None:
         user = UserCreate(
-            user_id="test_user_id_3",
-            username="test_username_3",
-            password="test_password_3",
-            retrieval_key="test_retrieval_key_3",
+            user_id="test_user_id_4",
+            username="test_username_4",
+            password="test_password_4",
+            retrieval_key="test_retrieval_key_4",
         )
         saved_user = await save_user_to_db(user, asession)
-        assert saved_user.hashed_retrieval_key == get_key_hash("test_retrieval_key_3")
+        assert saved_user.hashed_retrieval_key == get_key_hash("test_retrieval_key_4")
 
         updated_user = await update_user_retrieval_key(saved_user, "new_key", asession)
-        assert updated_user.hashed_retrieval_key != get_key_hash("test_retrieval_key_3")
+        assert updated_user.hashed_retrieval_key != get_key_hash("test_retrieval_key_4")
         assert updated_user.hashed_retrieval_key == get_key_hash("new_key")

--- a/core_backend/tests/api/test_users.py
+++ b/core_backend/tests/api/test_users.py
@@ -1,0 +1,81 @@
+from datetime import datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core_backend.app.users.models import (
+    UserAlreadyExistsError,
+    UserDB,
+    UserNotFoundError,
+    get_user_by_token,
+    get_user_by_username,
+    save_user_to_db,
+    update_user_retrieval_key,
+)
+from core_backend.app.users.schemas import UserCreate
+from core_backend.app.utils import get_key_hash
+from core_backend.tests.api.conftest import (
+    TEST_PASSWORD,
+    TEST_USER_ID,
+    TEST_USER_RETRIEVAL_KEY,
+    TEST_USERNAME,
+)
+
+
+@pytest.mark.asyncio(scope="module")
+async def test_save_user_to_db(db_session: AsyncSession) -> None:
+    user = UserCreate(
+        user_id="2", username="test2", password="password2", retrieval_key="key2"
+    )
+    saved_user = await save_user_to_db(user, db_session)
+    assert saved_user.username == "test2"
+
+
+@pytest.mark.asyncio(scope="module")
+async def test_save_user_to_db_existing_user(db_session: AsyncSession) -> None:
+    user = UserCreate(
+        user_id=TEST_USER_ID,
+        username=TEST_USERNAME,
+        password=TEST_PASSWORD,
+        retrieval_key=TEST_USER_RETRIEVAL_KEY,
+    )
+    with pytest.raises(UserAlreadyExistsError):
+        await save_user_to_db(user, db_session)
+
+
+@pytest.mark.asyncio(scope="module")
+async def test_get_user_by_username(db_session: AsyncSession) -> None:
+    retrieved_user = await get_user_by_username(TEST_USERNAME, db_session)
+    assert retrieved_user.username == TEST_USERNAME
+
+
+@pytest.mark.asyncio(scope="module")
+async def test_get_user_by_username_no_user(db_session: AsyncSession) -> None:
+    with pytest.raises(UserNotFoundError):
+        await get_user_by_username("nonexistent", db_session)
+
+
+@pytest.mark.asyncio(scope="module")
+async def test_get_user_by_token(db_session: AsyncSession) -> None:
+    retrieved_user = await get_user_by_token(TEST_USER_RETRIEVAL_KEY, db_session)
+    assert retrieved_user.username == TEST_USERNAME
+
+
+@pytest.mark.asyncio(scope="module")
+async def test_get_user_by_token_no_user(db_session: AsyncSession) -> None:
+    with pytest.raises(UserNotFoundError):
+        await get_user_by_token("nonexistent", db_session)
+
+
+@pytest.mark.asyncio(scope="module")
+async def test_update_user_retrieval_key(db_session: AsyncSession) -> None:
+    user_db = UserDB(
+        user_id=TEST_USER_ID,
+        username=TEST_USERNAME,
+        hashed_password=get_key_hash(TEST_PASSWORD),
+        hashed_retrieval_key=get_key_hash("new_key"),
+        created_datetime_utc=datetime.utcnow(),
+        updated_datetime_utc=datetime.utcnow(),
+    )
+    updated_user = await update_user_retrieval_key(user_db, "new_key", db_session)
+    assert updated_user.hashed_retrieval_key != get_key_hash(TEST_USER_RETRIEVAL_KEY)

--- a/core_backend/tests/api/test_users.py
+++ b/core_backend/tests/api/test_users.py
@@ -1,11 +1,11 @@
-from datetime import datetime
+from typing import AsyncGenerator
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from core_backend.app.database import get_async_session
 from core_backend.app.users.models import (
     UserAlreadyExistsError,
-    UserDB,
     UserNotFoundError,
     get_user_by_token,
     get_user_by_username,
@@ -22,60 +22,60 @@ from core_backend.tests.api.conftest import (
 )
 
 
-@pytest.mark.asyncio(scope="module")
-async def test_save_user_to_db(db_session: AsyncSession) -> None:
-    user = UserCreate(
-        user_id="2", username="test2", password="password2", retrieval_key="key2"
-    )
-    saved_user = await save_user_to_db(user, db_session)
-    assert saved_user.username == "test2"
+class TestUsers:
+    @pytest.fixture(scope="function")
+    async def asession(self) -> AsyncGenerator[AsyncSession, None]:
+        async for session in get_async_session():
+            yield session
 
+        await session.close()
 
-@pytest.mark.asyncio(scope="module")
-async def test_save_user_to_db_existing_user(db_session: AsyncSession) -> None:
-    user = UserCreate(
-        user_id=TEST_USER_ID,
-        username=TEST_USERNAME,
-        password=TEST_PASSWORD,
-        retrieval_key=TEST_USER_RETRIEVAL_KEY,
-    )
-    with pytest.raises(UserAlreadyExistsError):
-        await save_user_to_db(user, db_session)
+    async def test_save_user_to_db(self, asession: AsyncSession) -> None:
+        user = UserCreate(
+            user_id="test_user_id_2",
+            username="test_username_2",
+            password="test_password_2",
+            retrieval_key="test_retrieval_key_2",
+        )
+        saved_user = await save_user_to_db(user, asession)
+        assert saved_user.username == "test_username_2"
 
+    async def test_save_user_to_db_existing_user(self, asession: AsyncSession) -> None:
+        user = UserCreate(
+            user_id=TEST_USER_ID,
+            username=TEST_USERNAME,
+            password=TEST_PASSWORD,
+            retrieval_key=TEST_USER_RETRIEVAL_KEY,
+        )
+        with pytest.raises(UserAlreadyExistsError):
+            await save_user_to_db(user, asession)
 
-@pytest.mark.asyncio(scope="module")
-async def test_get_user_by_username(db_session: AsyncSession) -> None:
-    retrieved_user = await get_user_by_username(TEST_USERNAME, db_session)
-    assert retrieved_user.username == TEST_USERNAME
+    async def test_get_user_by_username(self, asession: AsyncSession) -> None:
+        retrieved_user = await get_user_by_username(TEST_USERNAME, asession)
+        assert retrieved_user.username == TEST_USERNAME
 
+    async def test_get_user_by_username_no_user(self, asession: AsyncSession) -> None:
+        with pytest.raises(UserNotFoundError):
+            await get_user_by_username("nonexistent", asession)
 
-@pytest.mark.asyncio(scope="module")
-async def test_get_user_by_username_no_user(db_session: AsyncSession) -> None:
-    with pytest.raises(UserNotFoundError):
-        await get_user_by_username("nonexistent", db_session)
+    async def test_get_user_by_token(self, asession: AsyncSession) -> None:
+        retrieved_user = await get_user_by_token(TEST_USER_RETRIEVAL_KEY, asession)
+        assert retrieved_user.username == TEST_USERNAME
 
+    async def test_get_user_by_token_no_user(self, asession: AsyncSession) -> None:
+        with pytest.raises(UserNotFoundError):
+            await get_user_by_token("nonexistent", asession)
 
-@pytest.mark.asyncio(scope="module")
-async def test_get_user_by_token(db_session: AsyncSession) -> None:
-    retrieved_user = await get_user_by_token(TEST_USER_RETRIEVAL_KEY, db_session)
-    assert retrieved_user.username == TEST_USERNAME
+    async def test_update_user_retrieval_key(self, asession: AsyncSession) -> None:
+        user = UserCreate(
+            user_id="test_user_id_3",
+            username="test_username_3",
+            password="test_password_3",
+            retrieval_key="test_retrieval_key_3",
+        )
+        saved_user = await save_user_to_db(user, asession)
+        assert saved_user.hashed_retrieval_key == get_key_hash("test_retrieval_key_3")
 
-
-@pytest.mark.asyncio(scope="module")
-async def test_get_user_by_token_no_user(db_session: AsyncSession) -> None:
-    with pytest.raises(UserNotFoundError):
-        await get_user_by_token("nonexistent", db_session)
-
-
-@pytest.mark.asyncio(scope="module")
-async def test_update_user_retrieval_key(db_session: AsyncSession) -> None:
-    user_db = UserDB(
-        user_id=TEST_USER_ID,
-        username=TEST_USERNAME,
-        hashed_password=get_key_hash(TEST_PASSWORD),
-        hashed_retrieval_key=get_key_hash("new_key"),
-        created_datetime_utc=datetime.utcnow(),
-        updated_datetime_utc=datetime.utcnow(),
-    )
-    updated_user = await update_user_retrieval_key(user_db, "new_key", db_session)
-    assert updated_user.hashed_retrieval_key != get_key_hash(TEST_USER_RETRIEVAL_KEY)
+        updated_user = await update_user_retrieval_key(saved_user, "new_key", asession)
+        assert updated_user.hashed_retrieval_key != get_key_hash("test_retrieval_key_3")
+        assert updated_user.hashed_retrieval_key == get_key_hash("new_key")

--- a/core_backend/tests/api/test_users.py
+++ b/core_backend/tests/api/test_users.py
@@ -15,8 +15,6 @@ from core_backend.app.users.models import (
 from core_backend.app.users.schemas import UserCreate
 from core_backend.app.utils import get_key_hash
 from core_backend.tests.api.conftest import (
-    TEST_PASSWORD,
-    TEST_USER_ID,
     TEST_USER_RETRIEVAL_KEY,
     TEST_USERNAME,
 )
@@ -31,22 +29,12 @@ class TestUsers:
         await session.close()
 
     async def test_save_user_to_db(self, asession: AsyncSession) -> None:
-        user = UserCreate(
-            user_id="test_user_id_3",
-            username="test_username_3",
-            password="test_password_3",
-            retrieval_key="test_retrieval_key_3",
-        )
+        user = UserCreate(username="test_username_3")
         saved_user = await save_user_to_db(user, asession)
         assert saved_user.username == "test_username_3"
 
     async def test_save_user_to_db_existing_user(self, asession: AsyncSession) -> None:
-        user = UserCreate(
-            user_id=TEST_USER_ID,
-            username=TEST_USERNAME,
-            password=TEST_PASSWORD,
-            retrieval_key=TEST_USER_RETRIEVAL_KEY,
-        )
+        user = UserCreate(username=TEST_USERNAME)
         with pytest.raises(UserAlreadyExistsError):
             await save_user_to_db(user, asession)
 
@@ -67,15 +55,10 @@ class TestUsers:
             await get_user_by_token("nonexistent", asession)
 
     async def test_update_user_retrieval_key(self, asession: AsyncSession) -> None:
-        user = UserCreate(
-            user_id="test_user_id_4",
-            username="test_username_4",
-            password="test_password_4",
-            retrieval_key="test_retrieval_key_4",
-        )
+        user = UserCreate(username="test_username_4")
         saved_user = await save_user_to_db(user, asession)
-        assert saved_user.hashed_retrieval_key == get_key_hash("test_retrieval_key_4")
+        assert saved_user.hashed_retrieval_key is None
 
         updated_user = await update_user_retrieval_key(saved_user, "new_key", asession)
-        assert updated_user.hashed_retrieval_key != get_key_hash("test_retrieval_key_4")
+        assert updated_user.hashed_retrieval_key is not None
         assert updated_user.hashed_retrieval_key == get_key_hash("new_key")

--- a/docs/develop/setup.md
+++ b/docs/develop/setup.md
@@ -58,13 +58,26 @@ The admin app will be available on [https://localhost](https://localhost) and th
         export PROMETHEUS_MULTIPROC_DIR=/tmp  # required for core_backend
         export NEXT_PUBLIC_GOOGLE_LOGIN_CLIENT_ID=<YOUR_CLIENT_ID> # optional
 
-4. (optional) Edit which LLMs are used in the `deployment/docker-compose/litellm_proxy_config.yaml`.
+4. (optional) Set custom login credentials by setting the following environment variables. The defaults
+can be found in `core_backend/add_users_to_db.py`.
 
-5. Run Make target to set up required Docker containers for the database and the LiteLLM proxy server.
+        # user 1
+        export USER1_USERNAME = "user1"
+        export USER1_PASSWORD = "fullaccess"
+        export USER1_RETRIEVAL_SECRET = "user1-key"
+
+        # user 2
+        export USER2_USERNAME = "user2"
+        export USER2_PASSWORD = "fullaccess"
+        export USER2_RETRIEVAL_SECRET = "user2-key"
+
+5. (optional) Edit which LLMs are used in the `deployment/docker-compose/litellm_proxy_config.yaml`.
+
+6. Run Make target to set up required Docker containers for the database and the LiteLLM proxy server.
 
         make setup-dev
 
-6. Run the app
+7. Run the app
 
         python core_backend/main.py
 
@@ -73,7 +86,7 @@ The admin app will be available on [https://localhost](https://localhost) and th
 
      You can test the endpoints by going to [http://localhost:8000/docs](http://localhost:8000/docs) (backend will be running on [http://localhost:8000](http://localhost:8000)).
 
-7. Once done, exit the running app process with `ctrl+c` and run
+8. Once done, exit the running app process with `ctrl+c` and run
 
         make teardown-dev
 


### PR DESCRIPTION
Reviewer: @suzinyou 
Estimate: 30mins

---

## Ticket

Fixes: [518](https://idinsight.atlassian.net/browse/AAQ-518?atlOrigin=eyJpIjoiMzQ1ZWM1YjU0ODJmNDFiYThmOGIyMWRlNjBkMjBiMTMiLCJwIjoiaiJ9)

## Description

### Goal

Add pytests for 
- the api key rotation endpoint
- user table functions
- content CRUD user overlaps
- UD CRUD
- user2 token denial for retrieval and UD detect

## How has this been tested?

- Activate the aaq environment and run `make tests` in core_backend
- Added where to find login credentials to dev docs

## Checklist

Fill with `x` for completed. Delete any lines that are not relevant

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have updated the automated tests (if applicable)
- [x] I have updated the requirements (if applicable)
