### PR TITLE
[AAQ-559] remove service identity var and improve rag reasoning

### DIFF
--- a/core_backend/app/config.py
+++ b/core_backend/app/config.py
@@ -24,7 +24,7 @@ LITELLM_API_KEY = os.environ.get("LITELLM_API_KEY", "dummy-key")
 # for all of its endpoints.
 LITELLM_MODEL_EMBEDDING = os.environ.get("LITELLM_MODEL_EMBEDDING", "openai/embeddings")
 LITELLM_MODEL_DEFAULT = os.environ.get("LITELLM_MODEL_DEFAULT", "openai/default")
-LITELLM_MODEL_SUMMARIZATION = os.environ.get(
+LITELLM_MODEL_GENERATION = os.environ.get(
     "LITELLM_MODEL_SUMMARIZATION", "openai/generate-response"
 )
 LITELLM_MODEL_LANGUAGE_DETECT = os.environ.get(

--- a/core_backend/app/config.py
+++ b/core_backend/app/config.py
@@ -25,7 +25,7 @@ LITELLM_API_KEY = os.environ.get("LITELLM_API_KEY", "dummy-key")
 LITELLM_MODEL_EMBEDDING = os.environ.get("LITELLM_MODEL_EMBEDDING", "openai/embeddings")
 LITELLM_MODEL_DEFAULT = os.environ.get("LITELLM_MODEL_DEFAULT", "openai/default")
 LITELLM_MODEL_GENERATION = os.environ.get(
-    "LITELLM_MODEL_SUMMARIZATION", "openai/generate-response"
+    "LITELLM_MODEL_GENERATION", "openai/generate-response"
 )
 LITELLM_MODEL_LANGUAGE_DETECT = os.environ.get(
     "LITELLM_MODEL_LANGUAGE_DETECT", "openai/detect-language"

--- a/core_backend/app/llm_call/process_output.py
+++ b/core_backend/app/llm_call/process_output.py
@@ -21,7 +21,7 @@ from ..question_answer.schemas import (
 )
 from ..utils import get_http_client, setup_logger
 from .llm_prompts import AlignmentScore
-from .utils import _ask_llm_async
+from .utils import _ask_llm_async, remove_json_markdown
 
 logger = setup_logger("OUTPUT RAILS")
 
@@ -148,7 +148,7 @@ async def _get_alignScore_score(
 
 
 async def _get_llm_align_score(
-    align_score_data: AlignScoreData, metadata: Optional[dict]
+    align_score_data: AlignScoreData, metadata: Optional[dict] = None
 ) -> AlignmentScore:
     """
     Get the alignment score from the LLM
@@ -159,9 +159,11 @@ async def _get_llm_align_score(
         prompt=prompt,
         litellm_model=LITELLM_MODEL_ALIGNSCORE,
         metadata=metadata,
+        json=True,
     )
 
     try:
+        result = remove_json_markdown(result)
         alignment_score = AlignmentScore.model_validate_json(result)
     except ValidationError as e:
         logger.error(f"LLM alignment score response is not valid json: {e}")

--- a/core_backend/app/llm_call/utils.py
+++ b/core_backend/app/llm_call/utils.py
@@ -14,12 +14,17 @@ async def _ask_llm_async(
     litellm_model: Optional[str] = LITELLM_MODEL_DEFAULT,
     litellm_endpoint: Optional[str] = LITELLM_ENDPOINT,
     metadata: Optional[dict] = None,
+    json: bool = False,
 ) -> str:
     """
     This is a generic function to ask the LLM model a question.
     """
     if metadata is not None:
         metadata["generation_name"] = litellm_model
+
+    extra_kwargs = {}
+    if json:
+        extra_kwargs["response_format"] = {"type": "json_object"}
 
     messages = [
         {
@@ -37,10 +42,16 @@ async def _ask_llm_async(
         model=litellm_model,
         messages=messages,
         temperature=0,
+        max_tokens=1024,
         api_base=litellm_endpoint,
         api_key=LITELLM_API_KEY,
         metadata=metadata,
+        **extra_kwargs,
     )
     logger.info(f"LLM output: {llm_response_raw.choices[0].message.content}")
-
     return llm_response_raw.choices[0].message.content
+
+
+def remove_json_markdown(text: str) -> str:
+    """Remove json markdown from text."""
+    return text.removeprefix("```json").removesuffix("```").strip()

--- a/core_backend/app/question_answer/routers.py
+++ b/core_backend/app/question_answer/routers.py
@@ -11,7 +11,6 @@ from ..database import get_async_session
 from ..llm_call.llm_prompts import ANSWER_FAILURE_MESSAGE
 from ..llm_call.llm_rag import get_llm_rag_answer
 from ..llm_call.process_input import (
-    classify_on_off_topic__before,
     classify_safety__before,
     identify_language__before,
     paraphrase_question__before,
@@ -93,7 +92,6 @@ async def llm_response(
 @identify_language__before
 @translate_question__before
 @classify_safety__before
-@classify_on_off_topic__before
 @paraphrase_question__before
 async def get_llm_answer(
     question: QueryRefined,
@@ -131,20 +129,21 @@ async def get_llm_answer(
         response.content_response = content_response
         context = get_context_string_from_retrieved_contents(content_response)
 
-        llm_response = await get_llm_rag_answer(
+        rag_response = await get_llm_rag_answer(
             question=question.query_text,
             context=context,
             response_language=question.original_language,
             metadata=metadata,
         )
 
-        if llm_response == ANSWER_FAILURE_MESSAGE:
+        if rag_response.answer == ANSWER_FAILURE_MESSAGE:
             response.state = ResultState.ERROR
             response.llm_response = None
-            response.debug_info["reason"] = "Response generation failed"
         else:
             response.state = ResultState.FINAL
-            response.llm_response = llm_response
+            response.llm_response = rag_response.answer
+
+        response.debug_info["extracted_info"] = rag_response.extracted_info
 
     return response
 
@@ -216,7 +215,6 @@ async def embeddings_search(
 
 @identify_language__before
 @translate_question__before
-@classify_on_off_topic__before
 @paraphrase_question__before
 async def get_semantic_matches(
     question: QueryRefined,

--- a/core_backend/app/question_answer/utils.py
+++ b/core_backend/app/question_answer/utils.py
@@ -26,6 +26,10 @@ def get_context_string_from_retrieved_contents(
     """
     context_list = []
     for i, result in content_response.items():
-        context_list.append(f"{i+1}. {result.retrieved_title}\n{result.retrieved_text}")
+        if not isinstance(result, QuerySearchResult):
+            result = QuerySearchResult(**result)
+        context_list.append(
+            f"{int(i)+1}. {result.retrieved_title}\n{result.retrieved_text}"
+        )
     context_string = "\n\n".join(context_list)
     return context_string

--- a/core_backend/tests/api/conftest.py
+++ b/core_backend/tests/api/conftest.py
@@ -23,7 +23,11 @@ from core_backend.app.contents.config import PGVECTOR_VECTOR_SIZE
 from core_backend.app.contents.models import ContentDB
 from core_backend.app.database import get_session
 from core_backend.app.llm_call import process_input, process_output
-from core_backend.app.llm_call.llm_prompts import AlignmentScore, IdentifiedLanguage
+from core_backend.app.llm_call.llm_prompts import (
+    RAG,
+    AlignmentScore,
+    IdentifiedLanguage,
+)
 from core_backend.app.question_answer.schemas import (
     QueryRefined,
     QueryResponse,
@@ -231,8 +235,8 @@ def patch_llm_call(monkeysession: pytest.MonkeyPatch) -> None:
     )
 
 
-async def patched_llm_rag_answer(*args: Any, **kwargs: Any) -> str:
-    return "monkeypatched_llm_response"
+async def patched_llm_rag_answer(*args: Any, **kwargs: Any) -> RAG:
+    return RAG(answer="patched llm response", extracted_info=[])
 
 
 async def mock_get_align_score(*args: Any, **kwargs: Any) -> AlignmentScore:

--- a/core_backend/tests/api/test.env
+++ b/core_backend/tests/api/test.env
@@ -6,4 +6,3 @@ POSTGRES_PORT=5433
 LITELLM_MODEL_DEFAULT="gpt-3.5-turbo-1106"
 PROMETHEUS_MULTIPROC_DIR=/tmp
 ALIGN_SCORE_API="http://localhost:5002/alignscore_base"
-SERVICE_IDENTITY="General Purpose Question Answering Chatbot"

--- a/deployment/docker-compose/template.env
+++ b/deployment/docker-compose/template.env
@@ -27,9 +27,6 @@ JWT_SECRET="jwt-secret"
 # N_TOP_CONTENT_FOR_SEARCH=
 # N_TOP_CONTENT_FOR_RAG=
 
-### Service Identity for off-topic detection
-SERVICE_IDENTITY="Public Health Chatbot"
-
 #### Variables for LiteLLM Proxy
 OPENAI_API_KEY="sk-..."
 GEMINI_API_KEY="..."


### PR DESCRIPTION
Reviewer: @lickem22 
Estimate: 30 min

---

## Ticket

Fixes: https://idinsight.atlassian.net/browse/AAQ-559

## Description

### Goal

Overall improve the RAG pipeline

### Changes

1. Improve reasoning in RAG prompt and return a json object
2. Remove SERVICE_IDENTITY from prompts -- should we just remove the topic check also?
3. Also removed SA languages we don't support

### Future Tasks (optional)

- [ ] improve groundedness & response language of output

## How has this been tested?

- locally with docker-compose
- on AAQ deployed instance
- unit tests
- Also tested alignscore: 38/48 cases passed


## Checklist

Fill with `x` for completed. 

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts

(Delete any items below that are not relevant)
- [x] I have updated the automated tests
- [ ] I have added a blogpost in Latest Updates  --> I will write one after further improvements this sprint!
