### PR TITLE
[Hotfix] prefix trace_id with project name or random string

### DIFF
--- a/core_backend/app/llm_call/process_input.py
+++ b/core_backend/app/llm_call/process_input.py
@@ -20,7 +20,7 @@ from ..question_answer.schemas import (
     QueryResponseError,
     ResultState,
 )
-from ..utils import setup_logger
+from ..utils import create_langfuse_metadata, setup_logger
 from .llm_prompts import (
     PARAPHRASE_FAILED_MESSAGE,
     PARAPHRASE_PROMPT,
@@ -50,12 +50,9 @@ def identify_language__before(func: Callable) -> Callable:
         """
         Wrapper function to identify the language of the question.
         """
-        metadata = {
-            "trace_id": "query_id-" + str(response.query_id),
-        }
-
-        if "user_id" in kwargs:
-            metadata["trace_user_id"] = "user_id-" + str(kwargs["user_id"])
+        metadata = create_langfuse_metadata(
+            query_id=response.query_id, user_id=kwargs.get("user_id", None)
+        )
 
         question, response = await _identify_language(
             question, response, metadata=metadata
@@ -155,11 +152,9 @@ def translate_question__before(func: Callable) -> Callable:
         """
         Wrapper function to translate the question.
         """
-        metadata = {
-            "trace_id": "query_id-" + str(response.query_id),
-        }
-        if "user_id" in kwargs:
-            metadata["trace_user_id"] = "user_id-" + str(kwargs["user_id"])
+        metadata = create_langfuse_metadata(
+            query_id=response.query_id, user_id=kwargs.get("user_id", None)
+        )
 
         question, response = await _translate_question(
             question, response, metadata=metadata
@@ -233,11 +228,9 @@ def classify_safety__before(func: Callable) -> Callable:
         """
         Wrapper function to classify the safety of the question.
         """
-        metadata = {
-            "trace_id": "query_id-" + str(response.query_id),
-        }
-        if "user_id" in kwargs:
-            metadata["trace_user_id"] = "user_id-" + str(kwargs["user_id"])
+        metadata = create_langfuse_metadata(
+            query_id=response.query_id, user_id=kwargs.get("user_id", None)
+        )
 
         question, response = await _classify_safety(
             question, response, metadata=metadata
@@ -305,11 +298,9 @@ def classify_on_off_topic__before(func: Callable) -> Callable:
         """
         Wrapper function to check if the question is on-topic or off-topic.
         """
-        metadata = {
-            "trace_id": "query_id-" + str(response.query_id),
-        }
-        if "user_id" in kwargs:
-            metadata["trace_user_id"] = "user_id-" + str(kwargs["user_id"])
+        metadata = create_langfuse_metadata(
+            query_id=response.query_id, user_id=kwargs.get("user_id", None)
+        )
 
         question, response = await _classify_on_off_topic(
             question, response, metadata=metadata
@@ -376,11 +367,10 @@ def paraphrase_question__before(func: Callable) -> Callable:
         """
         Wrapper function to paraphrase the question.
         """
-        metadata = {
-            "trace_id": "query_id-" + str(response.query_id),
-        }
-        if "user_id" in kwargs:
-            metadata["trace_user_id"] = "user_id-" + str(kwargs["user_id"])
+        metadata = create_langfuse_metadata(
+            query_id=response.query_id, user_id=kwargs.get("user_id", None)
+        )
+
         question, response = await _paraphrase_question(
             question, response, metadata=metadata
         )

--- a/core_backend/app/llm_call/process_output.py
+++ b/core_backend/app/llm_call/process_output.py
@@ -19,7 +19,7 @@ from ..question_answer.schemas import (
     QueryResponseError,
     ResultState,
 )
-from ..utils import get_http_client, setup_logger
+from ..utils import create_langfuse_metadata, get_http_client, setup_logger
 from .llm_prompts import AlignmentScore
 from .utils import _ask_llm_async
 
@@ -97,7 +97,7 @@ async def _check_align_score(
         else:
             raise ValueError("Method is AlignScore but ALIGN_SCORE_API is not set.")
     elif ALIGN_SCORE_METHOD == "LLM":
-        metadata = {"trace_id": "query_id-" + str(llm_response.query_id)}
+        metadata = create_langfuse_metadata(query_id=llm_response.query_id)
         align_score = await _get_llm_align_score(align_score_data, metadata=metadata)
     else:
         raise NotImplementedError(f"Unknown method {ALIGN_SCORE_METHOD}")

--- a/core_backend/app/question_answer/routers.py
+++ b/core_backend/app/question_answer/routers.py
@@ -19,7 +19,7 @@ from ..llm_call.process_input import (
 )
 from ..llm_call.process_output import check_align_score__after
 from ..users.models import UserDB
-from ..utils import generate_secret_key, setup_logger
+from ..utils import create_langfuse_metadata, generate_secret_key, setup_logger
 from .config import N_TOP_CONTENT_FOR_RAG, N_TOP_CONTENT_FOR_SEARCH
 from .models import (
     QueryDB,
@@ -114,10 +114,7 @@ async def get_llm_answer(
         )
 
     if not isinstance(response, QueryResponseError):
-        metadata = {
-            "trace_id": "query_id-" + str(response.query_id),
-            "trace_user_id": "user_id-" + str(user_id),
-        }
+        metadata = create_langfuse_metadata(query_id=response.query_id, user_id=user_id)
         content_response = convert_search_results_to_schema(
             await get_similar_content_async(
                 user_id=user_id,
@@ -229,10 +226,7 @@ async def get_semantic_matches(
     Get similar contents from content table
     """
     if not isinstance(response, QueryResponseError):
-        metadata = {
-            "trace_id": "query_id-" + str(response.query_id),
-            "trace_user_id": "user_id-" + str(user_id),
-        }
+        metadata = create_langfuse_metadata(query_id=response.query_id, user_id=user_id)
         content_response = convert_search_results_to_schema(
             await get_similar_content_async(
                 user_id=user_id,

--- a/core_backend/app/users/models.py
+++ b/core_backend/app/users/models.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Mapped, mapped_column
 
 from ..models import Base
-from ..utils import get_key_hash, get_password_salted_hash, get_random_password
+from ..utils import get_key_hash, get_password_salted_hash, get_random_string
 from .schemas import UserCreate, UserCreateWithPassword
 
 PASSWORD_LENGTH = 12
@@ -68,7 +68,7 @@ async def save_user_to_db(
     if isinstance(user, UserCreateWithPassword):
         hashed_password = get_password_salted_hash(user.password)
     else:
-        random_password = get_random_password(PASSWORD_LENGTH)
+        random_password = get_random_string(PASSWORD_LENGTH)
         hashed_password = get_password_salted_hash(random_password)
 
     content_db = UserDB(

--- a/core_backend/app/utils.py
+++ b/core_backend/app/utils.py
@@ -7,9 +7,11 @@ from typing import List, Optional
 from uuid import uuid4
 
 import aiohttp
+import litellm
 from litellm import aembedding
 
 from .config import (
+    LANGFUSE,
     LITELLM_API_KEY,
     LITELLM_ENDPOINT,
     LITELLM_MODEL_EMBEDDING,
@@ -51,11 +53,32 @@ def verify_password_salted_hash(key: str, stored_hash: str) -> bool:
     return hash_obj.hexdigest() == original_hash
 
 
-def get_random_password(size: int) -> str:
+def get_random_string(size: int) -> str:
     import random
     import string
 
     return "".join(random.choices(string.ascii_letters + string.digits, k=size))
+
+
+def create_langfuse_metadata(query_id: int, user_id: int | None = None) -> dict:
+    prefix = ""
+
+    if LANGFUSE == "True":
+        try:
+            project_name = (
+                litellm.utils.langFuseLogger.Langfuse.client.projects.get().data[0].name
+            )
+            prefix = project_name + "-"
+        except Exception:
+            prefix = get_random_string(8) + "-"
+
+    metadata = {
+        "trace_id": prefix + "query_id-" + str(query_id),
+    }
+    if user_id is not None:
+        metadata["trace_user_id"] = "user_id-" + str(user_id)
+
+    return metadata
 
 
 def get_log_level_from_str(log_level_str: str = LOG_LEVEL) -> int:

--- a/core_backend/app/utils.py
+++ b/core_backend/app/utils.py
@@ -7,8 +7,8 @@ from typing import List, Optional
 from uuid import uuid4
 
 import aiohttp
-import litellm
 from litellm import aembedding
+from litellm.utils import langFuseLogger
 
 from .config import (
     LANGFUSE,
@@ -54,6 +54,7 @@ def verify_password_salted_hash(key: str, stored_hash: str) -> bool:
 
 
 def get_random_string(size: int) -> str:
+    """Generate a random string of fixed length."""
     import random
     import string
 
@@ -61,13 +62,12 @@ def get_random_string(size: int) -> str:
 
 
 def create_langfuse_metadata(query_id: int, user_id: int | None = None) -> dict:
+    """Create metadata for langfuse logging."""
     prefix = ""
 
     if LANGFUSE == "True":
         try:
-            project_name = (
-                litellm.utils.langFuseLogger.Langfuse.client.projects.get().data[0].name
-            )
+            project_name = langFuseLogger.Langfuse.client.projects.get().data[0].name
             prefix = project_name + "-"
         except Exception:
             prefix = get_random_string(8) + "-"

--- a/core_backend/app/utils.py
+++ b/core_backend/app/utils.py
@@ -7,8 +7,8 @@ from typing import List, Optional
 from uuid import uuid4
 
 import aiohttp
+import litellm
 from litellm import aembedding
-from litellm.utils import langFuseLogger
 
 from .config import (
     LANGFUSE,
@@ -67,7 +67,9 @@ def create_langfuse_metadata(query_id: int, user_id: int | None = None) -> dict:
 
     if LANGFUSE == "True":
         try:
-            project_name = langFuseLogger.Langfuse.client.projects.get().data[0].name
+            project_name = (
+                litellm.utils.langFuseLogger.Langfuse.client.projects.get().data[0].name
+            )
             prefix = project_name + "-"
         except Exception:
             prefix = get_random_string(8) + "-"

--- a/deployment/docker-compose/template.env
+++ b/deployment/docker-compose/template.env
@@ -73,8 +73,8 @@ URGENCY_DETECTION_MIN_PROBABILITY=0.5 # only uses if using `llm_entailment_class
 NEXT_PUBLIC_GOOGLE_LOGIN_CLIENT_ID="update-me"
 
 #### Logging
-LANGFUSE=False # Set to True to enable Langfuse logging.
-# required if LANGFUSE=True
+## To enable langfuse logging, set LANGFUSE=True and set the keys
+LANGFUSE=False
 LANGFUSE_PUBLIC_KEY="pk-..."
 LANGFUSE_SECRET_KEY="sk-..."
 # optional based on your Langfuse host


### PR DESCRIPTION
Reviewer: @amiraliemami 
Estimate: 15 min

---

## Ticket

Fixes: None

## Description

### Goal

Langfuse doesn't log the same trace_id in different projects:
https://github.com/langfuse/langfuse/issues/1050

This was causing internal server error from Langfuse, and potential memory leak

### Changes

- Prefix trace_id with langfuse project name if it exists (which it should..)
- Otheriwse use random string

### Future Tasks (optional)

## How has this been tested?

Once Langfuse issue is solved, we can remove this logic.

1. Create a langfuse account
2. Create API key
3. Make a few AAQ requests
4. Create another project and API key
5. Make a few AAQ request with new API key (new project)
6. Ensure that there new requests are logged to the new project

## To-do before merge (optional)

## Checklist

Fill with `x` for completed. 

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts

(Delete any items below that are not relevant)
- [ ] I have updated the automated tests
