### PR TITLE
Fixed Db connection and string

### DIFF
--- a/core_backend/Makefile
+++ b/core_backend/Makefile
@@ -9,7 +9,7 @@ tests: setup-test-containers run-tests teardown-test-containers
 run-tests:
 	@set -a && source ./tests/api/test.env && set +a && \
 	python -m alembic upgrade head && \
-	python -m pytest -rPQ -m "not rails"
+	python -m pytest -rPQ -m "not rails" tests
 
 ## Helper targets
 setup-test-containers: setup-test-db

--- a/core_backend/app/config.py
+++ b/core_backend/app/config.py
@@ -69,3 +69,6 @@ EMBEDDINGS_ENDPOINT = os.environ.get(
 
 # Logging
 LANGFUSE = os.environ.get("LANGFUSE", "False")
+
+# Database
+DB_POOL_SIZE = os.environ.get("DB_POOL_SIZE", 20)  # Number of connections in the pool

--- a/core_backend/app/database.py
+++ b/core_backend/app/database.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engin
 from sqlalchemy.orm import Session
 
 from .config import (
+    DB_POOL_SIZE,
     POSTGRES_DB,
     POSTGRES_HOST,
     POSTGRES_PASSWORD,
@@ -55,7 +56,7 @@ def get_sqlalchemy_async_engine() -> AsyncEngine:
     global _ASYNC_ENGINE
     if _ASYNC_ENGINE is None:
         connection_string = build_connection_string()
-        _ASYNC_ENGINE = create_async_engine(connection_string, pool_size=20)
+        _ASYNC_ENGINE = create_async_engine(connection_string, pool_size=DB_POOL_SIZE)
     return _ASYNC_ENGINE
 
 

--- a/core_backend/app/database.py
+++ b/core_backend/app/database.py
@@ -1,10 +1,11 @@
+import contextlib
 import os
 from collections.abc import AsyncGenerator, Generator
+from typing import AsyncContextManager, ContextManager
 
 from sqlalchemy.engine import Engine, create_engine
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 from sqlalchemy.orm import Session
-from sqlalchemy.pool import NullPool
 
 from .config import (
     POSTGRES_DB,
@@ -54,8 +55,18 @@ def get_sqlalchemy_async_engine() -> AsyncEngine:
     global _ASYNC_ENGINE
     if _ASYNC_ENGINE is None:
         connection_string = build_connection_string()
-        _ASYNC_ENGINE = create_async_engine(connection_string, poolclass=NullPool)
+        _ASYNC_ENGINE = create_async_engine(connection_string, pool_size=20)
     return _ASYNC_ENGINE
+
+
+def get_session_context_manager() -> ContextManager[Session]:
+    """Return a SQLAlchemy session context manager."""
+    return contextlib.contextmanager(get_session)()
+
+
+def get_async_session_context_manager() -> AsyncContextManager[AsyncSession]:
+    """Return a SQLAlchemy async session context manager."""
+    return contextlib.asynccontextmanager(get_async_session)()
 
 
 def get_session() -> Generator[Session, None, None]:

--- a/core_backend/app/database.py
+++ b/core_backend/app/database.py
@@ -1,7 +1,5 @@
-import contextlib
 import os
 from collections.abc import AsyncGenerator, Generator
-from typing import AsyncContextManager, ContextManager
 
 from sqlalchemy.engine import Engine, create_engine
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
@@ -58,16 +56,6 @@ def get_sqlalchemy_async_engine() -> AsyncEngine:
         connection_string = build_connection_string()
         _ASYNC_ENGINE = create_async_engine(connection_string, pool_size=DB_POOL_SIZE)
     return _ASYNC_ENGINE
-
-
-def get_session_context_manager() -> ContextManager[Session]:
-    """Return a SQLAlchemy session context manager."""
-    return contextlib.contextmanager(get_session)()
-
-
-def get_async_session_context_manager() -> AsyncContextManager[AsyncSession]:
-    """Return a SQLAlchemy async session context manager."""
-    return contextlib.asynccontextmanager(get_async_session)()
 
 
 def get_session() -> Generator[Session, None, None]:

--- a/core_backend/tests/api/test_urgency_detect.py
+++ b/core_backend/tests/api/test_urgency_detect.py
@@ -1,10 +1,9 @@
-from typing import AsyncGenerator, Callable
+from typing import Callable
 
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from core_backend.app.database import get_async_session
 from core_backend.app.urgency_detection.routers import ALL_URGENCY_CLASSIFIERS
 from core_backend.app.urgency_detection.schemas import UrgencyQuery, UrgencyResponse
 from core_backend.tests.api.conftest import (
@@ -76,12 +75,6 @@ class TestUrgencyDetectionToken:
 
 
 class TestUrgencyClassifiers:
-    @pytest.fixture(scope="function")
-    async def asession(self) -> AsyncGenerator[AsyncSession, None]:
-        async for session in get_async_session():
-            yield session
-
-        await session.close()
 
     @pytest.mark.parametrize("classifier", ALL_URGENCY_CLASSIFIERS.values())
     async def test_classifier(

--- a/core_backend/tests/api/test_users.py
+++ b/core_backend/tests/api/test_users.py
@@ -1,9 +1,6 @@
-from typing import AsyncGenerator
-
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from core_backend.app.database import get_async_session
 from core_backend.app.users.models import (
     UserAlreadyExistsError,
     UserNotFoundError,
@@ -21,12 +18,6 @@ from core_backend.tests.api.conftest import (
 
 
 class TestUsers:
-    @pytest.fixture(scope="function")
-    async def asession(self) -> AsyncGenerator[AsyncSession, None]:
-        async for session in get_async_session():
-            yield session
-
-        await session.close()
 
     async def test_save_user_to_db(self, asession: AsyncSession) -> None:
         user = UserCreate(username="test_username_3")


### PR DESCRIPTION
Reviewer: @amiraliemami 
Estimate: 30mins

---

## Ticket

Fixes: JIRA_TICKET_LINK

## Description

### Goal

We had issues where db was reusing connection across different event loops.
We did a temporary fix by setting pooling to NullPool. This meant that we didn't keep a pool of connections and created a new connection for each request. 

But the downside is:
1. It is slower. There is an overhead for every connection
2. Once connections reach 100 (max connection right now on our postgres instance), the new ones are dropped
3. If we were using pooling, it would be added to the queue.

### Changes

We probably shouldn't change the core code to make tests work. This changes tests to make them work.
* Removed NullPool and made it 20 connections in pool
* Created engine again in conftest so that it's in the same event loop as the tests

## How has this been tested?

Tests pass

## To-do before merge (optional)

## Checklist

Fill with `x` for completed. 

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts

(Delete any items below that are not relevant)
- [x] I have updated the automated tests
- [ ] I have updated the scripts in `scripts/`
- [ ] I have updated the requirements
- [ ] I have updated the README file
- [ ] I have updated affected documentation
- [ ] I have added a blogpost in Latest Updates
- [ ] I have updated the CI/CD scripts in `.github/workflows/`
- [ ] I have updated the Terraform code
