### PR TITLE
Add content download button

### DIFF
--- a/admin_app/package-lock.json
+++ b/admin_app/package-lock.json
@@ -1499,12 +1499,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -2504,9 +2504,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"

--- a/admin_app/package-lock.json
+++ b/admin_app/package-lock.json
@@ -17,6 +17,7 @@
         "@types/google.accounts": "^0.0.14",
         "jwt-decode": "^4.0.0",
         "next": "14.1.3",
+        "papaparse": "^5.4.1",
         "react": "^18",
         "react-apexcharts": "^1.4.1",
         "react-dom": "^18"
@@ -3760,6 +3761,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/papaparse": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.4.1.tgz",
+      "integrity": "sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw=="
     },
     "node_modules/parent-module": {
       "version": "1.0.1",

--- a/admin_app/package.json
+++ b/admin_app/package.json
@@ -18,6 +18,7 @@
     "@types/google.accounts": "^0.0.14",
     "jwt-decode": "^4.0.0",
     "next": "14.1.3",
+    "papaparse": "^5.4.1",
     "react": "^18",
     "react-apexcharts": "^1.4.1",
     "react-dom": "^18"

--- a/admin_app/src/app/content/edit/page.tsx
+++ b/admin_app/src/app/content/edit/page.tsx
@@ -305,11 +305,11 @@ const ContentBox = ({
                   inputVal &&
                   !availableTags.some(
                     (tag) =>
-                      tag.tag_name.toUpperCase() === inputVal.toUpperCase()
+                      tag.tag_name.toUpperCase() === inputVal.toUpperCase(),
                   ) &&
                   !contentTags.some(
                     (tag) =>
-                      tag.tag_name.toUpperCase() === inputVal.toUpperCase()
+                      tag.tag_name.toUpperCase() === inputVal.toUpperCase(),
                   )
                 ) {
                   event.preventDefault();
@@ -532,7 +532,7 @@ const DiscardChangesModal = ({
           You have unsaved changes. Are you sure you want to discard them?
         </DialogContentText>
       </DialogContent>
-      <DialogActions>
+      <DialogActions sx={{ marginBottom: 1, marginRight: 1 }}>
         <Button onClick={onClose} color="primary" variant="contained">
           Cancel
         </Button>

--- a/admin_app/src/app/content/edit/page.tsx
+++ b/admin_app/src/app/content/edit/page.tsx
@@ -385,7 +385,7 @@ const ContentBox = ({
           p: sizes.baseGap,
         }}
       >
-        <LanguageButtonBar expandable={true} />
+        {/* <LanguageButtonBar expandable={true} /> */}
         <Layout.Spacer multiplier={1} />
         <Typography variant="body2">Title</Typography>
         <Layout.Spacer multiplier={0.5} />

--- a/admin_app/src/app/content/page.tsx
+++ b/admin_app/src/app/content/page.tsx
@@ -105,42 +105,67 @@ const CardsPage = () => {
 const CardsUtilityStrip = ({ editAccess }: { editAccess: boolean }) => {
   const [openDownloadModal, setOpenDownloadModal] =
     React.useState<boolean>(false);
+  const [snackMessage, setSnackMessage] = React.useState<string | null>(null);
+
   return (
-    <Layout.FlexBox
-      key={"utility-strip"}
-      flexDirection={"row"}
-      justifyContent={"flex-right"}
-      alignItems={"right"}
-      sx={{
-        display: "flex",
-        alignSelf: "flex-end",
-        px: sizes.baseGap,
-      }}
-      gap={sizes.smallGap}
-    >
-      <Button
-        variant="contained"
-        disabled={!editAccess}
-        component={Link}
-        href="/content/edit"
-        startIcon={<Add />}
-      >
-        New
-      </Button>
-      <Button
-        variant="contained"
-        disabled={!editAccess}
-        onClick={() => {
-          setOpenDownloadModal(true);
+    <>
+      <Snackbar
+        open={snackMessage !== null}
+        autoHideDuration={6000}
+        onClose={() => {
+          setSnackMessage(null);
         }}
       >
-        <FileDownloadIcon />
-      </Button>
-      <DownloadModal
-        open={openDownloadModal}
-        onClose={() => setOpenDownloadModal(false)}
-      />
-    </Layout.FlexBox>
+        <Alert
+          onClose={() => {
+            setSnackMessage(null);
+          }}
+          severity="error"
+          variant="filled"
+          sx={{ width: "100%" }}
+        >
+          {snackMessage}
+        </Alert>
+      </Snackbar>
+      <Layout.FlexBox
+        key={"utility-strip"}
+        flexDirection={"row"}
+        justifyContent={"flex-right"}
+        alignItems={"right"}
+        sx={{
+          display: "flex",
+          alignSelf: "flex-end",
+          px: sizes.baseGap,
+        }}
+        gap={sizes.smallGap}
+      >
+        <Button
+          variant="contained"
+          disabled={!editAccess}
+          component={Link}
+          href="/content/edit"
+          startIcon={<Add />}
+        >
+          New
+        </Button>
+        <Button
+          variant="contained"
+          disabled={!editAccess}
+          onClick={() => {
+            setOpenDownloadModal(true);
+          }}
+        >
+          <FileDownloadIcon />
+        </Button>
+        <DownloadModal
+          open={openDownloadModal}
+          onClose={() => setOpenDownloadModal(false)}
+          onFailedDownload={() => {
+            setSnackMessage(`Failed to download content`);
+          }}
+        />
+      </Layout.FlexBox>
+    </>
   );
 };
 

--- a/admin_app/src/app/content/page.tsx
+++ b/admin_app/src/app/content/page.tsx
@@ -192,7 +192,7 @@ const CardsUtilityStrip = ({
         }}
         onNoDataFound={() => {
           setSnackMessage({
-            message: `No data found to download`,
+            message: `No data to download`,
             color: "info",
           });
         }}

--- a/admin_app/src/app/content/page.tsx
+++ b/admin_app/src/app/content/page.tsx
@@ -40,6 +40,10 @@ const CardsPage = () => {
   const [filterTags, setFilterTags] = React.useState<Tag[]>([]);
   const [currAccessLevel, setCurrAccessLevel] = React.useState("readonly");
   const { token, accessLevel } = useAuth();
+  const [snackMessage, setSnackMessage] = React.useState<{
+    message: string | null;
+    color: "success" | "info" | "warning" | "error" | undefined;
+  }>({ message: null, color: undefined });
 
   React.useEffect(() => {
     const fetchTags = async () => {
@@ -51,126 +55,149 @@ const CardsPage = () => {
   }, [accessLevel]);
 
   return (
-    <Layout.FlexBox alignItems="center" gap={sizes.baseGap}>
-      <Layout.Spacer multiplier={3} />
-      <Layout.FlexBox
-        gap={sizes.smallGap}
-        sx={{
-          width: "70%",
-          maxWidth: "500px",
-          minWidth: "200px",
-        }}
-      >
-        <SearchBar searchTerm={searchTerm} setSearchTerm={setSearchTerm} />
-        <Layout.FlexBox
-          alignItems="center"
-          sx={{ flexDirection: "row", justifyContent: "center" }}
-          gap={sizes.smallGap}
-        >
-          <FilterListIcon sx={{ width: "auto", flexShrink: 0 }} />
-          <Autocomplete
-            multiple
-            limitTags={3}
-            id="tags-autocomplete"
-            options={tags}
-            getOptionLabel={(option) => option.tag_name}
-            value={filterTags}
-            onChange={(event, updatedTags) => {
-              setFilterTags(updatedTags);
-            }}
-            renderInput={(params) => (
-              <TextField
-                {...params}
-                variant="outlined"
-                label="Tags"
-                placeholder="Add Tags"
-              />
-            )}
-            sx={{ width: "80%" }}
-          />
-        </Layout.FlexBox>
-      </Layout.FlexBox>
-      <CardsUtilityStrip editAccess={currAccessLevel === "fullaccess"} />
-      <CardsGrid
-        displayLanguage={displayLanguage}
-        searchTerm={searchTerm}
-        tags={tags}
-        filterTags={filterTags}
-        token={token}
-        accessLevel={currAccessLevel}
-      />
-    </Layout.FlexBox>
-  );
-};
-
-const CardsUtilityStrip = ({ editAccess }: { editAccess: boolean }) => {
-  const [openDownloadModal, setOpenDownloadModal] =
-    React.useState<boolean>(false);
-  const [snackMessage, setSnackMessage] = React.useState<string | null>(null);
-
-  return (
     <>
       <Snackbar
-        open={snackMessage !== null}
+        open={snackMessage.message !== null}
         autoHideDuration={6000}
         onClose={() => {
-          setSnackMessage(null);
+          setSnackMessage({ message: null, color: snackMessage.color });
         }}
       >
         <Alert
           onClose={() => {
-            setSnackMessage(null);
+            setSnackMessage({ message: null, color: snackMessage.color });
           }}
-          severity="error"
+          severity={snackMessage.color}
           variant="filled"
           sx={{ width: "100%" }}
         >
-          {snackMessage}
+          {snackMessage.message}
         </Alert>
       </Snackbar>
-      <Layout.FlexBox
-        key={"utility-strip"}
-        flexDirection={"row"}
-        justifyContent={"flex-right"}
-        alignItems={"right"}
-        sx={{
-          display: "flex",
-          alignSelf: "flex-end",
-          px: sizes.baseGap,
-        }}
-        gap={sizes.smallGap}
-      >
-        <Tooltip title="Download all contents">
-          <Button
-            variant="outlined"
-            disabled={!editAccess}
-            onClick={() => {
-              setOpenDownloadModal(true);
-            }}
-          >
-            <DownloadIcon />
-          </Button>
-        </Tooltip>
-        <Tooltip title="Add new content">
-          <Button
-            variant="contained"
-            disabled={!editAccess}
-            component={Link}
-            href="/content/edit"
-            startIcon={<Add />}
-          >
-            New
-          </Button>
-        </Tooltip>
-        <DownloadModal
-          open={openDownloadModal}
-          onClose={() => setOpenDownloadModal(false)}
-          onFailedDownload={() => {
-            setSnackMessage(`Failed to download content`);
+      <Layout.FlexBox alignItems="center" gap={sizes.baseGap}>
+        <Layout.Spacer multiplier={3} />
+        <Layout.FlexBox
+          gap={sizes.smallGap}
+          sx={{
+            width: "70%",
+            maxWidth: "500px",
+            minWidth: "200px",
           }}
+        >
+          <SearchBar searchTerm={searchTerm} setSearchTerm={setSearchTerm} />
+          <Layout.FlexBox
+            alignItems="center"
+            sx={{ flexDirection: "row", justifyContent: "center" }}
+            gap={sizes.smallGap}
+          >
+            <FilterListIcon sx={{ width: "auto", flexShrink: 0 }} />
+            <Autocomplete
+              multiple
+              limitTags={3}
+              id="tags-autocomplete"
+              options={tags}
+              getOptionLabel={(option) => option.tag_name}
+              value={filterTags}
+              onChange={(event, updatedTags) => {
+                setFilterTags(updatedTags);
+              }}
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  variant="outlined"
+                  label="Tags"
+                  placeholder="Add Tags"
+                />
+              )}
+              sx={{ width: "80%" }}
+            />
+          </Layout.FlexBox>
+        </Layout.FlexBox>
+        <CardsUtilityStrip
+          editAccess={currAccessLevel === "fullaccess"}
+          setSnackMessage={setSnackMessage}
+        />
+        <CardsGrid
+          displayLanguage={displayLanguage}
+          searchTerm={searchTerm}
+          tags={tags}
+          filterTags={filterTags}
+          token={token}
+          accessLevel={currAccessLevel}
+          setSnackMessage={setSnackMessage}
         />
       </Layout.FlexBox>
     </>
+  );
+};
+
+const CardsUtilityStrip = ({
+  editAccess,
+  setSnackMessage,
+}: {
+  editAccess: boolean;
+  setSnackMessage: React.Dispatch<
+    React.SetStateAction<{
+      message: string | null;
+      color: "success" | "info" | "warning" | "error" | undefined;
+    }>
+  >;
+}) => {
+  const [openDownloadModal, setOpenDownloadModal] =
+    React.useState<boolean>(false);
+
+  return (
+    <Layout.FlexBox
+      key={"utility-strip"}
+      flexDirection={"row"}
+      justifyContent={"flex-right"}
+      alignItems={"right"}
+      sx={{
+        display: "flex",
+        alignSelf: "flex-end",
+        px: sizes.baseGap,
+      }}
+      gap={sizes.smallGap}
+    >
+      <Tooltip title="Download all contents">
+        <Button
+          variant="outlined"
+          disabled={!editAccess}
+          onClick={() => {
+            setOpenDownloadModal(true);
+          }}
+        >
+          <DownloadIcon />
+        </Button>
+      </Tooltip>
+      <Tooltip title="Add new content">
+        <Button
+          variant="contained"
+          disabled={!editAccess}
+          component={Link}
+          href="/content/edit"
+          startIcon={<Add />}
+        >
+          New
+        </Button>
+      </Tooltip>
+      <DownloadModal
+        open={openDownloadModal}
+        onClose={() => setOpenDownloadModal(false)}
+        onFailedDownload={() => {
+          setSnackMessage({
+            message: `Failed to download content`,
+            color: "error",
+          });
+        }}
+        onNoDataFound={() => {
+          setSnackMessage({
+            message: `No data found to download`,
+            color: "info",
+          });
+        }}
+      />
+    </Layout.FlexBox>
   );
 };
 
@@ -181,6 +208,7 @@ const CardsGrid = ({
   filterTags,
   token,
   accessLevel,
+  setSnackMessage,
 }: {
   displayLanguage: string;
   searchTerm: string;
@@ -188,6 +216,12 @@ const CardsGrid = ({
   filterTags: Tag[];
   token: string | null;
   accessLevel: string;
+  setSnackMessage: React.Dispatch<
+    React.SetStateAction<{
+      message: string | null;
+      color: "success" | "info" | "warning" | "error" | undefined;
+    }>
+  >;
 }) => {
   const [page, setPage] = React.useState<number>(1);
   const [max_pages, setMaxPages] = React.useState<number>(1);
@@ -198,27 +232,35 @@ const CardsGrid = ({
   const action = searchParams.get("action") || null;
   const content_id = Number(searchParams.get("content_id")) || null;
 
-  const getSnackMessage = (
-    action: string | null,
-    content_id: number | null,
-  ): string | null => {
-    if (action === "edit") {
-      return `Content #${content_id} updated`;
-    } else if (action === "add") {
-      return `Content #${content_id} created`;
-    }
-    return null;
-  };
-
-  const [snackMessage, setSnackMessage] = React.useState<string | null>(
-    getSnackMessage(action, content_id),
+  const getSnackMessage = React.useCallback(
+    (action: string | null, content_id: number | null): string | null => {
+      if (action === "edit") {
+        return `Content #${content_id} updated`;
+      } else if (action === "add") {
+        return `Content #${content_id} created`;
+      }
+      return null;
+    },
+    [],
   );
+
+  React.useEffect(() => {
+    if (action) {
+      setSnackMessage({
+        message: getSnackMessage(action, content_id),
+        color: "success",
+      });
+    }
+  }, [action, content_id, getSnackMessage]);
 
   const [refreshKey, setRefreshKey] = React.useState(0);
   const onSuccessfulDelete = (content_id: number) => {
     setIsLoading(true);
     setRefreshKey((prevKey) => prevKey + 1);
-    setSnackMessage(`Content #${content_id} deleted successfully`);
+    setSnackMessage({
+      message: `Content #${content_id} deleted successfully`,
+      color: "success",
+    });
   };
 
   React.useEffect(() => {
@@ -247,6 +289,7 @@ const CardsGrid = ({
       })
       .catch((error) => {
         console.error("Failed to fetch content:", error);
+        setSnackMessage({ message: `Failed to fetch content`, color: "error" });
         setIsLoading(false);
       });
   }, [searchTerm, filterTags, token, refreshKey]);
@@ -283,24 +326,6 @@ const CardsGrid = ({
   }
   return (
     <>
-      <Snackbar
-        open={snackMessage !== null}
-        autoHideDuration={6000}
-        onClose={() => {
-          setSnackMessage(null);
-        }}
-      >
-        <Alert
-          onClose={() => {
-            setSnackMessage(null);
-          }}
-          severity="success"
-          variant="filled"
-          sx={{ width: "100%" }}
-        >
-          {snackMessage}
-        </Alert>
-      </Snackbar>
       <Layout.FlexBox
         bgcolor="lightgray.main"
         sx={{
@@ -341,9 +366,10 @@ const CardsGrid = ({
                       negative_votes={item.negative_votes}
                       onSuccessfulDelete={onSuccessfulDelete}
                       onFailedDelete={(content_id: number) => {
-                        setSnackMessage(
-                          `Failed to delete content #${content_id}`,
-                        );
+                        setSnackMessage({
+                          message: `Failed to delete content #${content_id}`,
+                          color: "error",
+                        });
                       }}
                       deleteContent={(content_id: number) => {
                         return apiCalls.deleteContent(content_id, token!);

--- a/admin_app/src/app/content/page.tsx
+++ b/admin_app/src/app/content/page.tsx
@@ -7,6 +7,7 @@ import { apiCalls } from "@/utils/api";
 import { useAuth } from "@/utils/auth";
 import { Add } from "@mui/icons-material";
 import FilterListIcon from "@mui/icons-material/FilterList";
+import FileDownloadIcon from "@mui/icons-material/FileDownload";
 import {
   Autocomplete,
   Button,
@@ -21,6 +22,7 @@ import { useSearchParams } from "next/navigation";
 import React from "react";
 import { PageNavigation } from "../../components/PageNavigation";
 import { SearchBar } from "../../components/SearchBar";
+import { DownloadModal } from "@/components/DownloadModal";
 
 const MAX_CARDS_TO_FETCH = 200;
 const MAX_CARDS_PER_PAGE = 12;
@@ -30,7 +32,7 @@ export interface Tag {
 }
 const CardsPage = () => {
   const [displayLanguage, setDisplayLanguage] = React.useState<string>(
-    LANGUAGE_OPTIONS[0].label
+    LANGUAGE_OPTIONS[0].label,
   );
   const [searchTerm, setSearchTerm] = React.useState<string>("");
   const [tags, setTags] = React.useState<Tag[]>([]);
@@ -65,7 +67,6 @@ const CardsPage = () => {
           gap={sizes.smallGap}
         >
           <FilterListIcon sx={{ width: "auto", flexShrink: 0 }} />
-
           <Autocomplete
             multiple
             limitTags={3}
@@ -102,6 +103,8 @@ const CardsPage = () => {
 };
 
 const CardsUtilityStrip = ({ editAccess }: { editAccess: boolean }) => {
+  const [openDownloadModal, setOpenDownloadModal] =
+    React.useState<boolean>(false);
   return (
     <Layout.FlexBox
       key={"utility-strip"}
@@ -113,17 +116,30 @@ const CardsUtilityStrip = ({ editAccess }: { editAccess: boolean }) => {
         alignSelf: "flex-end",
         px: sizes.baseGap,
       }}
-      gap={sizes.baseGap}
+      gap={sizes.smallGap}
     >
       <Button
         variant="contained"
         disabled={!editAccess}
         component={Link}
         href="/content/edit"
-        startIcon={<Add fontSize="small" />}
+        startIcon={<Add />}
       >
         New
       </Button>
+      <Button
+        variant="contained"
+        disabled={!editAccess}
+        onClick={() => {
+          setOpenDownloadModal(true);
+        }}
+      >
+        <FileDownloadIcon />
+      </Button>
+      <DownloadModal
+        open={openDownloadModal}
+        onClose={() => setOpenDownloadModal(false)}
+      />
     </Layout.FlexBox>
   );
 };
@@ -154,7 +170,7 @@ const CardsGrid = ({
 
   const getSnackMessage = (
     action: string | null,
-    content_id: number | null
+    content_id: number | null,
   ): string | null => {
     if (action === "edit") {
       return `Content #${content_id} updated`;
@@ -165,7 +181,7 @@ const CardsGrid = ({
   };
 
   const [snackMessage, setSnackMessage] = React.useState<string | null>(
-    getSnackMessage(action, content_id)
+    getSnackMessage(action, content_id),
   );
 
   const [refreshKey, setRefreshKey] = React.useState(0);
@@ -187,7 +203,7 @@ const CardsGrid = ({
             card.content_text.toLowerCase().includes(searchTerm.toLowerCase());
 
           const matchesAllTags = filterTags.some((fTag) =>
-            card.content_tags.includes(fTag.tag_id)
+            card.content_tags.includes(fTag.tag_id),
           );
 
           return (
@@ -268,7 +284,7 @@ const CardsGrid = ({
           {cards
             .slice(
               MAX_CARDS_PER_PAGE * (page - 1),
-              MAX_CARDS_PER_PAGE * (page - 1) + MAX_CARDS_PER_PAGE
+              MAX_CARDS_PER_PAGE * (page - 1) + MAX_CARDS_PER_PAGE,
             )
             .map((item) => {
               if (item.content_id !== null) {
@@ -290,7 +306,7 @@ const CardsGrid = ({
                       tags={
                         tags
                           ? tags.filter((tag) =>
-                              item.content_tags.includes(tag.tag_id)
+                              item.content_tags.includes(tag.tag_id),
                             )
                           : []
                       }
@@ -299,7 +315,7 @@ const CardsGrid = ({
                       onSuccessfulDelete={onSuccessfulDelete}
                       onFailedDelete={(content_id: number) => {
                         setSnackMessage(
-                          `Failed to delete content #${content_id}`
+                          `Failed to delete content #${content_id}`,
                         );
                       }}
                       deleteContent={(content_id: number) => {

--- a/admin_app/src/app/content/page.tsx
+++ b/admin_app/src/app/content/page.tsx
@@ -7,7 +7,8 @@ import { apiCalls } from "@/utils/api";
 import { useAuth } from "@/utils/auth";
 import { Add } from "@mui/icons-material";
 import FilterListIcon from "@mui/icons-material/FilterList";
-import FileDownloadIcon from "@mui/icons-material/FileDownload";
+import DownloadIcon from "@mui/icons-material/Download";
+import Tooltip from "@mui/material/Tooltip";
 import {
   Autocomplete,
   Button,
@@ -139,24 +140,28 @@ const CardsUtilityStrip = ({ editAccess }: { editAccess: boolean }) => {
         }}
         gap={sizes.smallGap}
       >
-        <Button
-          variant="contained"
-          disabled={!editAccess}
-          component={Link}
-          href="/content/edit"
-          startIcon={<Add />}
-        >
-          New
-        </Button>
-        <Button
-          variant="contained"
-          disabled={!editAccess}
-          onClick={() => {
-            setOpenDownloadModal(true);
-          }}
-        >
-          <FileDownloadIcon />
-        </Button>
+        <Tooltip title="Download all contents">
+          <Button
+            variant="outlined"
+            disabled={!editAccess}
+            onClick={() => {
+              setOpenDownloadModal(true);
+            }}
+          >
+            <DownloadIcon />
+          </Button>
+        </Tooltip>
+        <Tooltip title="Add new content">
+          <Button
+            variant="contained"
+            disabled={!editAccess}
+            component={Link}
+            href="/content/edit"
+            startIcon={<Add />}
+          >
+            New
+          </Button>
+        </Tooltip>
         <DownloadModal
           open={openDownloadModal}
           onClose={() => setOpenDownloadModal(false)}

--- a/admin_app/src/app/content/page.tsx
+++ b/admin_app/src/app/content/page.tsx
@@ -312,10 +312,7 @@ const CardsGrid = ({
       >
         <Grid container>
           {cards
-            .slice(
-              MAX_CARDS_PER_PAGE * (page - 1),
-              MAX_CARDS_PER_PAGE * (page - 1) + MAX_CARDS_PER_PAGE,
-            )
+            .slice(MAX_CARDS_PER_PAGE * (page - 1), MAX_CARDS_PER_PAGE * page)
             .map((item) => {
               if (item.content_id !== null) {
                 return (

--- a/admin_app/src/app/urgency-rules/page.tsx
+++ b/admin_app/src/app/urgency-rules/page.tsx
@@ -8,6 +8,7 @@ import {
   IconButton,
   InputAdornment,
   Button,
+  Tooltip,
 } from "@mui/material";
 import { Layout } from "@/components/Layout";
 import { sizes } from "@/utils";
@@ -177,14 +178,16 @@ const UrgencyRulesPage = () => {
             }}
             gap={sizes.baseGap}
           >
-            <Button
-              variant="contained"
-              disabled={currAccessLevel != "fullaccess" ? true : false}
-              onClick={() => createNewRecord()}
-              startIcon={<Add fontSize="small" />}
-            >
-              New
-            </Button>
+            <Tooltip title="Add new urgency rule">
+              <Button
+                variant="contained"
+                disabled={currAccessLevel != "fullaccess" ? true : false}
+                onClick={() => createNewRecord()}
+                startIcon={<Add fontSize="small" />}
+              >
+                New
+              </Button>
+            </Tooltip>
           </Layout.FlexBox>
           <List sx={{ width: "100%", pl: 1, bgcolor: "background.paper" }}>
             {items.map((urgencyRule: UrgencyRule, index: number) => {

--- a/admin_app/src/components/ContentCard.tsx
+++ b/admin_app/src/components/ContentCard.tsx
@@ -59,7 +59,7 @@ const ContentCard = ({
           flexDirection="row"
           justifyContent="space-between"
           alignItems="center"
-          sx={{ width: "100%" }}
+          sx={{ width: "98%" }}
         >
           <Typography variant="overline" sx={{ letterSpacing: 2 }}>
             #{content_id}
@@ -115,7 +115,6 @@ const ContentCard = ({
           gap={sizes.tinyGap}
           sx={{ alignItems: "center" }}
         >
-          <Layout.Spacer horizontal multiplier={0.2} />
           <Button
             disabled={!editAccess}
             component={Link}

--- a/admin_app/src/components/ContentCard.tsx
+++ b/admin_app/src/components/ContentCard.tsx
@@ -71,13 +71,16 @@ const ContentCard = ({
                 size="small"
                 sx={{
                   bgcolor: appColors.white,
-                  color: appColors.black,
+                  color: appColors.darkGrey,
                   border: "1px solid",
-                  borderColor: appColors.darkGrey,
+                  borderColor: appColors.lightGrey,
                 }}
               />
               {tags.length > 1 && (
-                <Typography variant="body2" sx={{ marginLeft: 1 }}>
+                <Typography
+                  variant="overline"
+                  sx={{ marginLeft: 0.3, color: appColors.darkGrey }}
+                >
                   +{tags.length - 1}
                 </Typography>
               )}

--- a/admin_app/src/components/ContentModal.tsx
+++ b/admin_app/src/components/ContentModal.tsx
@@ -95,8 +95,7 @@ const ContentViewModal = ({
                 </Layout.FlexBox>
               </Layout.FlexBox>
             )}
-            <LanguageButtonBar expandable={false} />
-
+            {/* <LanguageButtonBar expandable={false} /> */}
             <Layout.FlexBox
               flex={1}
               flexDirection={"column"}

--- a/admin_app/src/components/ContentModal.tsx
+++ b/admin_app/src/components/ContentModal.tsx
@@ -55,7 +55,7 @@ const ContentViewModal = ({
       <Fade in={!!open}>
         <Box
           sx={{
-            height: "80%",
+            maxHeight: "80vh",
             width: "80%",
             minWidth: "600px",
             borderRadius: 2,
@@ -99,93 +99,87 @@ const ContentViewModal = ({
             </Layout.FlexBox>
           )}
           <Layout.Spacer multiplier={0.5} />
+          {/* <LanguageButtonBar expandable={false} /> */}
           <Layout.FlexBox
             flexDirection={"column"}
             sx={{
-              height: "77%",
+              maxHeight: "50vh",
+              p: sizes.baseGap,
+              mr: sizes.baseGap,
+              overflowY: "auto",
+              border: 1,
+              borderColor: appColors.lightGrey,
+              borderRadius: 3,
             }}
           >
-            {/* <LanguageButtonBar expandable={false} /> */}
-            <Layout.FlexBox
-              flexDirection={"column"}
+            <Typography variant="subtitle1" sx={{ mb: sizes.baseGap }}>
+              {title}
+            </Typography>
+            <Typography
+              variant="body2"
               sx={{
-                p: sizes.baseGap,
-                mr: sizes.baseGap,
-                overflowY: "auto",
-                border: 1,
-                borderColor: appColors.lightGrey,
-                borderRadius: 3,
+                overflowWrap: "break-word",
+                hyphens: "auto",
+                whiteSpace: "pre-wrap",
               }}
             >
-              <Typography variant="subtitle1" sx={{ mb: sizes.baseGap }}>
-                {title}
-              </Typography>
-              <Typography
-                variant="body2"
-                sx={{
-                  overflowWrap: "break-word",
-                  hyphens: "auto",
-                  whiteSpace: "pre-wrap",
-                }}
+              {text}
+            </Typography>
+          </Layout.FlexBox>
+          <Layout.Spacer multiplier={2} />
+          <Layout.FlexBox
+            flexDirection={"row"}
+            gap={sizes.smallGap}
+            {...appStyles.justifyContentSpaceBetween}
+          >
+            <Layout.FlexBox
+              {...appStyles.alignItemsCenter}
+              flexDirection={"row"}
+            >
+              <Button
+                variant="contained"
+                color="primary"
+                disabled={!editAccess}
+                component={Link}
+                href={`/content/edit?content_id=${content_id}`}
               >
-                {text}
+                <Edit />
+                <Layout.Spacer horizontal multiplier={0.4} />
+                Edit
+              </Button>
+              <Layout.Spacer horizontal multiplier={1} />
+            </Layout.FlexBox>
+            <Layout.FlexBox
+              {...appStyles.alignItemsCenter}
+              flexDirection={"row"}
+            >
+              <Typography variant="body2" color={appColors.darkGrey}>
+                Last modified on{" "}
+                {new Date(last_modified).toLocaleString(undefined, {
+                  day: "numeric",
+                  month: "short",
+                  year: "numeric",
+                  hour: "numeric",
+                  minute: "numeric",
+                  hour12: true,
+                })}
               </Typography>
             </Layout.FlexBox>
-            <Layout.Spacer multiplier={2} />
             <Layout.FlexBox
               flexDirection={"row"}
-              gap={sizes.smallGap}
-              {...appStyles.justifyContentSpaceBetween}
+              gap={sizes.baseGap}
+              {...appStyles.alignItemsCenter}
+              {...appStyles.justifyContentCenter}
+              sx={{ pr: sizes.baseGap }}
             >
-              <Layout.FlexBox
-                {...appStyles.alignItemsCenter}
-                flexDirection={"row"}
-              >
-                <Button
-                  variant="contained"
-                  color="primary"
-                  disabled={!editAccess}
-                  component={Link}
-                  href={`/content/edit?content_id=${content_id}`}
-                >
-                  <Edit />
-                  <Layout.Spacer horizontal multiplier={0.4} />
-                  Edit
-                </Button>
-                <Layout.Spacer horizontal multiplier={1} />
-              </Layout.FlexBox>
-              <Layout.FlexBox
-                {...appStyles.alignItemsCenter}
-                flexDirection={"row"}
-              >
-                <Typography variant="body2" color={appColors.darkGrey}>
-                  Last modified on{" "}
-                  {new Date(last_modified).toLocaleString(undefined, {
-                    day: "numeric",
-                    month: "short",
-                    year: "numeric",
-                    hour: "numeric",
-                    minute: "numeric",
-                    hour12: true,
-                  })}
-                </Typography>
-              </Layout.FlexBox>
-              <Layout.FlexBox
-                flexDirection={"row"}
-                gap={sizes.baseGap}
-                {...appStyles.alignItemsCenter}
-                {...appStyles.justifyContentCenter}
-                sx={{ pr: sizes.baseGap }}
-              >
-                <ThumbUp fontSize="small" color="disabled" />
-                <Typography variant="body2" sx={{ color: appColors.darkGrey }}>
-                  {positive_votes}
-                </Typography>
-                <ThumbDown fontSize="small" color="disabled" />
-                <Typography variant="body2" sx={{ color: appColors.darkGrey }}>
-                  {negative_votes}
-                </Typography>
-              </Layout.FlexBox>
+              <ThumbUp fontSize="small" color="disabled" />
+              <Typography variant="body2" sx={{ color: appColors.darkGrey }}>
+                {positive_votes}
+              </Typography>
+              <ThumbDown fontSize="small" color="disabled" />
+              <Typography variant="body2" sx={{ color: appColors.darkGrey }}>
+                {negative_votes}
+              </Typography>
             </Layout.FlexBox>
           </Layout.FlexBox>
         </Box>

--- a/admin_app/src/components/ContentModal.tsx
+++ b/admin_app/src/components/ContentModal.tsx
@@ -1,6 +1,14 @@
 import { appColors, appStyles, sizes } from "@/utils";
 import { Close, Delete, Edit, ThumbDown, ThumbUp } from "@mui/icons-material";
-import { Box, Button, Chip, Fade, Modal, Typography } from "@mui/material";
+import {
+  Box,
+  Button,
+  Chip,
+  Fade,
+  IconButton,
+  Modal,
+  Typography,
+} from "@mui/material";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
@@ -49,7 +57,8 @@ const ContentViewModal = ({
           sx={{
             height: "80%",
             width: "80%",
-            minWidth: "500px",
+            minWidth: "600px",
+            borderRadius: 2,
             backgroundColor: appColors.white,
             p: sizes.doubleBaseGap,
           }}
@@ -59,61 +68,70 @@ const ContentViewModal = ({
             {...appStyles.justifyContentSpaceBetween}
           >
             <Typography variant="h5">Content #{content_id}</Typography>
-            <Close onClick={onClose} />
+            <IconButton onClick={onClose}>
+              <Close />
+            </IconButton>
           </Layout.FlexBox>
-
-          <Layout.Spacer multiplier={1} />
-
+          <Layout.Spacer multiplier={0.5} />
+          {tags && tags.length > 0 && (
+            <Layout.FlexBox
+              flexDirection={"column"}
+              sx={{
+                my: sizes.smallGap,
+              }}
+            >
+              <Typography variant="subtitle1" gutterBottom>
+                Tags
+              </Typography>
+              <Layout.FlexBox
+                flexDirection={"row"}
+                gap={sizes.smallGap}
+                {...appStyles.alignItemsCenter}
+                sx={{
+                  overflowX: "auto",
+                  py: sizes.smallGap,
+                }}
+              >
+                {tags.map((tag) => (
+                  <Chip key={tag.tag_id} label={tag.tag_name} />
+                ))}
+              </Layout.FlexBox>
+            </Layout.FlexBox>
+          )}
+          <Layout.Spacer multiplier={0.5} />
           <Layout.FlexBox
             flexDirection={"column"}
             sx={{
-              height: "80%",
+              height: "77%",
             }}
           >
-            {tags && tags.length > 0 && (
-              <Layout.FlexBox
-                flexDirection={"column"}
-                sx={{
-                  my: sizes.smallGap,
-                }}
-              >
-                <Typography variant="subtitle1" gutterBottom>
-                  Tags
-                </Typography>
-                <Layout.FlexBox
-                  flexDirection={"row"}
-                  gap={sizes.smallGap}
-                  {...appStyles.alignItemsCenter}
-                  sx={{
-                    overflowX: "auto",
-                    py: sizes.smallGap,
-                  }}
-                >
-                  {tags.map((tag) => (
-                    <Chip key={tag.tag_id} label={tag.tag_name} />
-                  ))}
-                </Layout.FlexBox>
-              </Layout.FlexBox>
-            )}
             {/* <LanguageButtonBar expandable={false} /> */}
             <Layout.FlexBox
-              flex={1}
               flexDirection={"column"}
               sx={{
                 p: sizes.baseGap,
                 mr: sizes.baseGap,
                 overflowY: "auto",
                 border: 1,
-                borderColor: appColors.outline,
-                borderRadius: 1,
+                borderColor: appColors.lightGrey,
+                borderRadius: 3,
               }}
             >
-              <Layout.Spacer multiplier={1} />
-              <Typography variant="subtitle1">{title}</Typography>
-              <Layout.Spacer multiplier={1} />
-              <Typography variant="body2">{text}</Typography>
+              <Typography variant="subtitle1" sx={{ mb: sizes.baseGap }}>
+                {title}
+              </Typography>
+              <Typography
+                variant="body2"
+                sx={{
+                  overflowWrap: "break-word",
+                  hyphens: "auto",
+                  whiteSpace: "pre-wrap",
+                }}
+              >
+                {text}
+              </Typography>
             </Layout.FlexBox>
-            <Layout.Spacer multiplier={1} />
+            <Layout.Spacer multiplier={2} />
             <Layout.FlexBox
               flexDirection={"row"}
               gap={sizes.smallGap}
@@ -159,12 +177,14 @@ const ContentViewModal = ({
                 {...appStyles.justifyContentCenter}
                 sx={{ pr: sizes.baseGap }}
               >
-                {/* <RemoveRedEye fontSize="small" color="disabled" /> */}
-                {/* <Typography variant="body2">_</Typography> */}
                 <ThumbUp fontSize="small" color="disabled" />
-                <Typography variant="body2">{positive_votes}</Typography>
+                <Typography variant="body2" sx={{ color: appColors.darkGrey }}>
+                  {positive_votes}
+                </Typography>
                 <ThumbDown fontSize="small" color="disabled" />
-                <Typography variant="body2">{negative_votes}</Typography>
+                <Typography variant="body2" sx={{ color: appColors.darkGrey }}>
+                  {negative_votes}
+                </Typography>
               </Layout.FlexBox>
             </Layout.FlexBox>
           </Layout.FlexBox>

--- a/admin_app/src/components/DownloadModal.tsx
+++ b/admin_app/src/components/DownloadModal.tsx
@@ -94,7 +94,16 @@ const DownloadModal = ({
       }
       // convert to csv
       const csv = Papa.unparse(processed_contents_json);
-      downloadCSV(csv, "content.csv");
+      const now = new Date();
+      const timestamp = `${now.getFullYear()}_${String(
+        now.getMonth() + 1,
+      ).padStart(2, "0")}_${String(now.getDate()).padStart(2, "0")}_${String(
+        now.getHours(),
+      ).padStart(2, "0")}${String(now.getMinutes()).padStart(2, "0")}${String(
+        now.getSeconds(),
+      ).padStart(2, "0")}`;
+      const filename = `content_${timestamp}.csv`;
+      downloadCSV(csv, filename);
     } catch (error) {
       console.error("Failed to download content", error);
       onFailedDownload();

--- a/admin_app/src/components/DownloadModal.tsx
+++ b/admin_app/src/components/DownloadModal.tsx
@@ -84,7 +84,13 @@ const DownloadModal = ({
     document.body.removeChild(link);
   };
 
-  const handleDownloadContent = async () => {
+  const handleDownloadContent = async (
+    fetchAndCleanContents: () => Promise<any[]>,
+    onNoDataFound: () => void,
+    onFailedDownload: () => void,
+    setLoading: (loading: boolean) => void,
+    onClose: () => void,
+  ) => {
     setLoading(true);
     try {
       const processed_contents_json = await fetchAndCleanContents();
@@ -92,7 +98,6 @@ const DownloadModal = ({
         onNoDataFound();
         return;
       }
-      // convert to csv
       const csv = Papa.unparse(processed_contents_json);
       const now = new Date();
       const timestamp = `${now.getFullYear()}_${String(
@@ -136,7 +141,15 @@ const DownloadModal = ({
           startIcon={<FileDownloadIcon />}
           loading={loading}
           loadingPosition="start"
-          onClick={handleDownloadContent}
+          onClick={() =>
+            handleDownloadContent(
+              fetchAndCleanContents,
+              onNoDataFound,
+              onFailedDownload,
+              setLoading,
+              onClose,
+            )
+          }
         >
           Download
         </LoadingButton>

--- a/admin_app/src/components/DownloadModal.tsx
+++ b/admin_app/src/components/DownloadModal.tsx
@@ -19,10 +19,12 @@ const DownloadModal = ({
   open,
   onClose,
   onFailedDownload,
+  onNoDataFound,
 }: {
   open: boolean;
   onClose: () => void;
   onFailedDownload: () => void;
+  onNoDataFound: () => void;
 }) => {
   const { token, accessLevel } = useAuth();
   const [loading, setLoading] = useState(false);
@@ -34,8 +36,12 @@ const DownloadModal = ({
       skip: 0,
       limit: MAX_CARDS_TO_FETCH,
     });
+    if (raw_json_data.length === 0) {
+      return [];
+    }
     // convert to list of json objects
     const json_data_list = Object.values(raw_json_data);
+
     // move content_id to be frst and drop user_id
     const ordered_json_data_list = json_data_list.map((item) => {
       const { user_id, content_id, ...rest } = item;
@@ -82,6 +88,10 @@ const DownloadModal = ({
     setLoading(true);
     try {
       const processed_contents_json = await fetchAndCleanContents();
+      if (processed_contents_json.length === 0) {
+        onNoDataFound();
+        return;
+      }
       // convert to csv
       const csv = Papa.unparse(processed_contents_json);
       downloadCSV(csv, "content.csv");

--- a/admin_app/src/components/DownloadModal.tsx
+++ b/admin_app/src/components/DownloadModal.tsx
@@ -18,9 +18,11 @@ const MAX_CARDS_TO_FETCH = 200;
 const DownloadModal = ({
   open,
   onClose,
+  onFailedDownload,
 }: {
   open: boolean;
   onClose: () => void;
+  onFailedDownload: () => void;
 }) => {
   const { token, accessLevel } = useAuth();
   const [loading, setLoading] = useState(false);
@@ -56,6 +58,7 @@ const DownloadModal = ({
       downloadCSV(csv, "content.csv");
     } catch (error) {
       console.error("Failed to download content", error);
+      onFailedDownload();
     } finally {
       setLoading(false);
       onClose();

--- a/admin_app/src/components/DownloadModal.tsx
+++ b/admin_app/src/components/DownloadModal.tsx
@@ -27,6 +27,46 @@ const DownloadModal = ({
   const { token, accessLevel } = useAuth();
   const [loading, setLoading] = useState(false);
 
+  const fetchAndCleanContents = async () => {
+    // fetch all contents
+    const raw_json_data = await apiCalls.getContentList({
+      token: token!,
+      skip: 0,
+      limit: MAX_CARDS_TO_FETCH,
+    });
+    // convert to list of json objects
+    const json_data_list = Object.values(raw_json_data);
+    // move content_id to be frst and drop user_id
+    const ordered_json_data_list = json_data_list.map((item) => {
+      const { user_id, content_id, ...rest } = item;
+      return {
+        content_id,
+        ...rest,
+      };
+    });
+    // stringify json element
+    const processed_contents_json = ordered_json_data_list.map((item) => {
+      return {
+        ...item,
+        content_metadata: JSON.stringify(item.content_metadata),
+      };
+    });
+    // get list of tags and replace tag ids with tag names
+    const tags_json = await apiCalls.getTagList(token!);
+    const tag_list = Object.values(tags_json);
+    const tag_dict = tag_list.reduce((acc, tag) => {
+      acc[tag.tag_id] = tag.tag_name;
+      return acc;
+    }, {});
+    processed_contents_json.forEach((item) => {
+      item.content_tags = item.content_tags.map(
+        (tag_id: number) => tag_dict[tag_id],
+      );
+    });
+
+    return processed_contents_json;
+  };
+
   const downloadCSV = (csvData: string, fileName: string) => {
     const blob = new Blob([csvData], { type: "text/csv" });
     const url = window.URL.createObjectURL(blob);
@@ -41,20 +81,9 @@ const DownloadModal = ({
   const handleDownloadContent = async () => {
     setLoading(true);
     try {
-      const raw_json_data = await apiCalls.getContentList({
-        token: token!,
-        skip: 0,
-        limit: MAX_CARDS_TO_FETCH,
-      });
-      const json_data_list = Object.values(raw_json_data);
-      const cleaned_json_data_list = json_data_list.map((item) => {
-        return {
-          ...item,
-          content_metadata: JSON.stringify(item.content_metadata),
-          content_tags: JSON.stringify(item.content_tags),
-        };
-      });
-      const csv = Papa.unparse(cleaned_json_data_list);
+      const processed_contents_json = await fetchAndCleanContents();
+      // convert to csv
+      const csv = Papa.unparse(processed_contents_json);
       downloadCSV(csv, "content.csv");
     } catch (error) {
       console.error("Failed to download content", error);

--- a/admin_app/src/components/DownloadModal.tsx
+++ b/admin_app/src/components/DownloadModal.tsx
@@ -1,0 +1,91 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from "@mui/material";
+import FileDownloadIcon from "@mui/icons-material/FileDownload";
+import { apiCalls } from "@/utils/api";
+import { useAuth } from "@/utils/auth";
+import Papa from "papaparse";
+
+const MAX_CARDS_TO_FETCH = 200;
+
+const DownloadModal = ({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}) => {
+  const { token, accessLevel } = useAuth();
+
+  const downloadCSV = (csvData: string, fileName: string) => {
+    const blob = new Blob([csvData], { type: "text/csv" });
+    const url = window.URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.setAttribute("download", fileName);
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+
+  const handleDownloadContent = async () => {
+    try {
+      const raw_json_data = await apiCalls.getContentList({
+        token: token!,
+        skip: 0,
+        limit: MAX_CARDS_TO_FETCH,
+      });
+      const json_data_list = Object.values(raw_json_data);
+      const cleaned_json_data_list = json_data_list.map((item) => {
+        return {
+          ...item,
+          content_metadata: JSON.stringify(item.content_metadata),
+          content_tags: JSON.stringify(item.content_tags),
+        };
+      });
+      const csv = Papa.unparse(cleaned_json_data_list);
+      downloadCSV(csv, "content.csv");
+    } catch (error) {
+      console.error("Failed to download content", error);
+    }
+  };
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      aria-labelledby="alert-dialog-title"
+      aria-describedby="alert-dialog-description"
+    >
+      <DialogTitle id="alert-dialog-title" sx={{ minWidth: "800px" }}>
+        {"Download all contents?"}
+      </DialogTitle>
+      <DialogContent>
+        <DialogContentText id="alert-dialog-description">
+          This action will download all contents as a CSV file.
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions sx={{ marginBottom: 1, marginRight: 1 }}>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          onClick={() => {
+            handleDownloadContent();
+            onClose();
+          }}
+          autoFocus
+          variant="contained"
+          color="primary"
+          startIcon={<FileDownloadIcon />}
+        >
+          Download
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export { DownloadModal };

--- a/admin_app/src/components/DownloadModal.tsx
+++ b/admin_app/src/components/DownloadModal.tsx
@@ -10,6 +10,8 @@ import FileDownloadIcon from "@mui/icons-material/FileDownload";
 import { apiCalls } from "@/utils/api";
 import { useAuth } from "@/utils/auth";
 import Papa from "papaparse";
+import { useState } from "react";
+import { LoadingButton } from "@mui/lab";
 
 const MAX_CARDS_TO_FETCH = 200;
 
@@ -21,6 +23,7 @@ const DownloadModal = ({
   onClose: () => void;
 }) => {
   const { token, accessLevel } = useAuth();
+  const [loading, setLoading] = useState(false);
 
   const downloadCSV = (csvData: string, fileName: string) => {
     const blob = new Blob([csvData], { type: "text/csv" });
@@ -34,6 +37,7 @@ const DownloadModal = ({
   };
 
   const handleDownloadContent = async () => {
+    setLoading(true);
     try {
       const raw_json_data = await apiCalls.getContentList({
         token: token!,
@@ -52,8 +56,12 @@ const DownloadModal = ({
       downloadCSV(csv, "content.csv");
     } catch (error) {
       console.error("Failed to download content", error);
+    } finally {
+      setLoading(false);
+      onClose();
     }
   };
+
   return (
     <Dialog
       open={open}
@@ -71,18 +79,16 @@ const DownloadModal = ({
       </DialogContent>
       <DialogActions sx={{ marginBottom: 1, marginRight: 1 }}>
         <Button onClick={onClose}>Cancel</Button>
-        <Button
-          onClick={() => {
-            handleDownloadContent();
-            onClose();
-          }}
-          autoFocus
+        <LoadingButton
           variant="contained"
-          color="primary"
+          autoFocus
           startIcon={<FileDownloadIcon />}
+          loading={loading}
+          loadingPosition="start"
+          onClick={handleDownloadContent}
         >
           Download
-        </Button>
+        </LoadingButton>
       </DialogActions>
     </Dialog>
   );

--- a/admin_app/src/components/PlaygroundComponents.tsx
+++ b/admin_app/src/components/PlaygroundComponents.tsx
@@ -452,7 +452,7 @@ const ApiKeyDialog = ({
           onChange={(e) => setApiKey(e.target.value)}
         />
       </DialogContent>
-      <DialogActions>
+      <DialogActions sx={{ marginBottom: 1, marginRight: 1 }}>
         <Button onClick={handleClose}>Cancel</Button>
         <Button variant="contained" onClick={() => handleSave(apiKey)}>
           Save


### PR DESCRIPTION
Reviewer: @sidravi1 for code, @Tanmay-97 for design.
Estimate: 20mins

---

## Ticket

Fixes: [555](https://idinsight.atlassian.net/browse/AAQ-555) and [572](https://idinsight.atlassian.net/browse/AAQ-572) (new)

## Description

### Goal

- Add functionality to download data as a CSV from the front-end

### Changes

- Button and modal and logic for downloading the CSV. Fetches contents and tags and does some cleanup before creating and saving the CSV.
- Some functional and aesthetic cleanups elsewhere in the app

### Future Tasks

- Standardise snackbars across the app. It's getting confusing.

## How has this been tested?

- Run dev and docker-compose deployment, add some contents with tags etc and click download and check the file

## Checklist

Fill with `x` for completed. 

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have updated the requirements