### PR TITLE
Fixed core_backend Dockerfile for windows

### DIFF
--- a/core_backend/Dockerfile
+++ b/core_backend/Dockerfile
@@ -5,7 +5,7 @@ ARG NAME=aaq_backend
 ARG PORT=8000
 ARG HOME_DIR=/usr/src/${NAME}
 RUN apt-get update && apt-get install -y \
-    gcc libpq-dev python3-dev
+    gcc libpq-dev python3-dev dos2unix
 
 COPY add_users_to_db.py /add_users_to_db.py
 
@@ -23,6 +23,9 @@ ENV PORT ${PORT}
 COPY . ${HOME_DIR}
 
 WORKDIR ${HOME_DIR}
+
+RUN find ${HOME_DIR} -type f -print0 | xargs -0 dos2unix
+
 RUN ["chmod", "+x", "startup.sh"]
 
 EXPOSE ${PORT}


### PR DESCRIPTION
Reviewer:  @suzinyou 
Estimate: 2 min

---

## Ticket

Fixes: 

## Description: 

### Goal 

The goal of this PR is to fix the issue of rogue EOLs '\r\n' in certain script files and to convert it back to '\n' while setting up the development environment.

### Changes

added a command in the the 'core_backend' dockerfile to convert rogue '\r' to '\n'

## How has this been tested?

by running the docker containers with `docker compose -f docker-compose.yml -f docker-compose.dev.yml -p aaq-stack watch` command

## Checklist

Fill with `x` for completed. 

- [ x ] My code follows the style guidelines of this project
- [ x ] I have reviewed my own code to ensure good quality
- [ x ] I have tested the functionality of my code to ensure it works as intended
- [ x ] I have resolved merge conflicts


