### PR TITLE
[Hotfix] remove translate and paraphrase from llm response

### DIFF
--- a/core_backend/app/llm_call/llm_prompts.py
+++ b/core_backend/app/llm_call/llm_prompts.py
@@ -239,12 +239,13 @@ from the fact that pineapples are a hybrid of pinecones and apples and its pinec
 -like shape."}}
 {{"extracted_info": [], "answer": "FAILED"}}
 
+REFERENCE TEXT:
+{context}
+
 IMPORTANT NOTES ON THE "answer" FIELD:
 - Answer in the language of the question.
 - Do not include any information that is not present in the REFERENCE TEXT.
-
-REFERENCE TEXT:
-{context}"""
+"""
 )
 
 

--- a/core_backend/app/question_answer/routers.py
+++ b/core_backend/app/question_answer/routers.py
@@ -90,9 +90,7 @@ async def llm_response(
 
 @check_align_score__after
 @identify_language__before
-@translate_question__before
 @classify_safety__before
-@paraphrase_question__before
 async def get_llm_answer(
     question: QueryRefined,
     response: QueryResponse,

--- a/docs/components/qa-service/llm-response.md
+++ b/docs/components/qa-service/llm-response.md
@@ -16,10 +16,8 @@ sequenceDiagram
   User->>AAQ: User's question
   AAQ->>LLM: Identify language
   LLM->>AAQ: <Language>
-  AAQ->>LLM: Translate text
-  LLM->>AAQ: <Translated Text>
-  AAQ->>LLM: Paraphrase question
-  LLM->>AAQ: <Paraphrased Question>
+  AAQ->>LLM: Check for safety
+  LLM->>AAQ: <Safety Classification>
   AAQ->>Vector DB: Request N most similar contents in DB
   Vector DB->>AAQ: <N contents with similarity score>
   AAQ->>LLM: Given contents, construct response in user's language to question
@@ -44,10 +42,8 @@ sequenceDiagram
   User->>AAQ: User's question
   AAQ->>LLM: Identify language
   LLM->>AAQ: <Language>
-  AAQ->>LLM: Translate text
-  LLM->>AAQ: <Translated Text>
-  AAQ->>LLM: Paraphrase question
-  LLM->>AAQ: <Paraphrased Question>
+  AAQ->>LLM: Check for safety
+  LLM->>AAQ: <Safety Classification>
   AAQ->>Vector DB: Request N most similar contents in DB
   Vector DB->>AAQ: <N contents with similarity score>
   AAQ->>LLM: Construct response to question given contents


### PR DESCRIPTION
Reviewer: @sidravi1  @Tanmay-97 
Estimate: 15 min

---

## Ticket

Fixes: - 

## Description

### Goal

We'll add guardrails/transformations after more testing and evals to assess which ones are necessary.

### Changes

1. Removes translation and paraphrasing in RAG response

### Future Tasks (optional)

1. Evaluate embeddings without translate and paraphrase -- if performance is worse, we should also do cost analysis
2. Whatever flow we arrive at for embeddings, we should apply for the retrieval part of RAG.

## How has this been tested?

## To-do before merge (optional)

## Checklist

Fill with `x` for completed. 

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts

(Delete any items below that are not relevant)
- [ ] I have updated the automated tests
- [ ] I have updated the scripts in `scripts/`
- [ ] I have updated the requirements
- [ ] I have updated the README file
- [x] I have updated affected documentation
- [ ] I have added a blogpost in Latest Updates
- [ ] I have updated the CI/CD scripts in `.github/workflows/`
- [ ] I have updated the Terraform code
