### PR TITLE
Changed UD to make just one LLM call per request

### DIFF
--- a/core_backend/app/llm_call/entailment.py
+++ b/core_backend/app/llm_call/entailment.py
@@ -17,7 +17,6 @@ async def detect_urgency(
     Detects the urgency of a message based on a set of urgency rules.
     """
 
-    "\n".join([f"{i+1}. {rule}" for i, rule in enumerate(urgency_rules)])
 
     ud_entailment = UrgencyDetectionEntailment(urgency_rules=urgency_rules)
     prompt = ud_entailment.get_prompt()

--- a/core_backend/app/llm_call/entailment.py
+++ b/core_backend/app/llm_call/entailment.py
@@ -17,7 +17,6 @@ async def detect_urgency(
     Detects the urgency of a message based on a set of urgency rules.
     """
 
-
     ud_entailment = UrgencyDetectionEntailment(urgency_rules=urgency_rules)
     prompt = ud_entailment.get_prompt()
 

--- a/core_backend/app/llm_call/entailment.py
+++ b/core_backend/app/llm_call/entailment.py
@@ -1,5 +1,5 @@
 from json import loads
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from ..config import LITELLM_MODEL_URGENCY_DETECT
 from .llm_prompts import get_urgency_detection_prompt
@@ -7,15 +7,19 @@ from .utils import _ask_llm_async
 
 
 async def detect_urgency(
-    urgency_rule: str, message: str, metadata: Optional[dict] = None
+    urgency_rules: List[str], message: str, metadata: Optional[dict] = None
 ) -> Dict[str, Any]:
     """
-    Detects the urgency of a message based on a given urgency rule.
+    Detects the urgency of a message based on a set of urgency rules.
     """
 
-    prompt = get_urgency_detection_prompt(urgency_rule, message)
+    if len(urgency_rules) == 0:
+        return {"is_urgent": False, "failed_rules": [], "details": {}}
+
+    prompt = get_urgency_detection_prompt(urgency_rules)
+
     json = await _ask_llm_async(
-        question="",
+        question=message,
         prompt=prompt,
         litellm_model=LITELLM_MODEL_URGENCY_DETECT,
         metadata=metadata,

--- a/core_backend/app/llm_call/entailment.py
+++ b/core_backend/app/llm_call/entailment.py
@@ -25,6 +25,7 @@ async def detect_urgency(
         prompt=prompt,
         litellm_model=LITELLM_MODEL_URGENCY_DETECT,
         metadata=metadata,
+        json=True,
     )
 
     try:

--- a/core_backend/app/llm_call/llm_prompts.py
+++ b/core_backend/app/llm_call/llm_prompts.py
@@ -372,8 +372,6 @@ class UrgencyDetectionEntailment:
         )
 
         if ud_entailment_result.best_matching_rule not in self._urgency_rules:
-            # use regex to strip the number and the dot from the rule
-
             raise ValueError(
                 (
                     f"Best_matching_rule {ud_entailment_result.best_matching_rule} is "

--- a/core_backend/app/llm_call/llm_prompts.py
+++ b/core_backend/app/llm_call/llm_prompts.py
@@ -292,29 +292,33 @@ class AlignmentScore(BaseModel):
     ).strip()
 
 
-def get_urgency_detection_prompt(condition: str, message: str) -> str:
+def get_urgency_detection_prompt(urgency_rules: List[str]) -> str:
     """
     Returns the prompt for the urgency detection bot.
     """
-
+    urgency_rules_str = "\n".join(
+        [f"{i+1}. {rule}" for i, rule in enumerate(urgency_rules)]
+    )
     return textwrap.dedent(
         (
-            """Given a [statement] and [comment], score the share of meaning
-            of [statement] covered by [comment].
-            Respond with a score between 0 and 1 with 0.1 increments.
+            """You are an urgency classification bot. Given a set of urgency rules
+            below, score if the user message is urgent or not. Respond with the
+            rule that is most consistent with the user message, the probability
+            between 0 and 1 with 0.1 of how closely the user message matches the rule,
+            and the reason for the probability.
             """
             """
             Respond in json string:
 
             \{
-               statement: str
+               best_matching_rule: str
                probability: float
                reason: str
             \}
             """
             f"""
-            statement: {condition}
-            comment: {message}
+            Urgency Rules:
+            {urgency_rules_str}
             """
         )
     ).strip()

--- a/core_backend/app/llm_call/utils.py
+++ b/core_backend/app/llm_call/utils.py
@@ -54,4 +54,8 @@ async def _ask_llm_async(
 
 def remove_json_markdown(text: str) -> str:
     """Remove json markdown from text."""
-    return text.removeprefix("```json").removesuffix("```").strip()
+
+    json_str = text.removeprefix("```json").removesuffix("```").strip()
+    json_str = json_str.replace("\{", "{").replace("\}", "}")
+
+    return json_str

--- a/core_backend/tests/api/conftest.py
+++ b/core_backend/tests/api/conftest.py
@@ -271,10 +271,10 @@ async def mock_return_args(
 
 
 async def mock_detect_urgency(
-    urgency_rule: str, message: str, metadata: Optional[dict]
+    urgency_rules: List[str], message: str, metadata: Optional[dict]
 ) -> Dict[str, Any]:
     return {
-        "statement": urgency_rule,
+        "best_matching_rule": "made up rule",
         "probability": 0.7,
         "reason": "this is a mocked response",
     }

--- a/core_backend/tests/api/test_urgency_detect.py
+++ b/core_backend/tests/api/test_urgency_detect.py
@@ -67,7 +67,6 @@ class TestUrgencyDetectionToken:
 
         if response.status_code == 200:
             is_urgent = response.json()["is_urgent"]
-            print(response.json())
             if expect_found:
                 # the breathing query should flag as urgent for user1. See
                 # data/urgency_rules.json which is loaded by the urgency_rules fixture.

--- a/core_backend/tests/api/test_urgency_detect.py
+++ b/core_backend/tests/api/test_urgency_detect.py
@@ -40,8 +40,10 @@ class TestUrgencyDetectionToken:
         assert response.status_code == expected_status_code
 
         if expected_status_code == 200:
-            json_content_response = response.json()["details"]
-            assert len(json_content_response.keys()) == urgency_rules
+            json_content_response = response.json()
+            assert isinstance(json_content_response["is_urgent"], bool)
+            probability = json_content_response["details"]["probability"]
+            assert probability >= 0.0 and probability <= 1.0
 
     @pytest.mark.parametrize(
         "token, expect_found",
@@ -65,6 +67,7 @@ class TestUrgencyDetectionToken:
 
         if response.status_code == 200:
             is_urgent = response.json()["is_urgent"]
+            print(response.json())
             if expect_found:
                 # the breathing query should flag as urgent for user1. See
                 # data/urgency_rules.json which is loaded by the urgency_rules fixture.


### PR DESCRIPTION
Reviewer: @suzinyou 
Estimate: 30mins

---

## Ticket

Fixes: N/A

While writing scripts for testing UD entailment, realised that the number of calls being made were not sustainable (one per id

## Description

### Goal

`llm_entailment` method only calls LLM once with all rules in context

### Changes

Updated prompt
Updated `llm_entailment_classifier`
Updated tests

## How has this been tested?

Tests pass

## Checklist

Fill with `x` for completed. 

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts

(Delete any items below that are not relevant)
- [x] I have updated the automated tests
- [ ] I have updated the scripts in `scripts/`
- [ ] I have updated the requirements
- [ ] I have updated the README file
- [ ] I have updated affected documentation
- [ ] I have added a blogpost in Latest Updates
- [ ] I have updated the CI/CD scripts in `.github/workflows/`
- [ ] I have updated the Terraform code
