### PR TITLE
[AAQ-580] remove content_language

### DIFF
--- a/admin_app/src/app/content/edit/page.tsx
+++ b/admin_app/src/app/content/edit/page.tsx
@@ -35,7 +35,6 @@ export interface Content extends EditContentBody {
 interface EditContentBody {
   content_title: string;
   content_text: string;
-  content_language: string;
   content_tags: number[];
   content_metadata: Record<string, unknown>;
 }
@@ -163,11 +162,11 @@ const ContentBox = ({
         const defaultTags =
           content && content.content_tags.length > 0
             ? content.content_tags.map((tag_id) =>
-                data.find((tag) => tag.tag_id === tag_id)
+                data.find((tag) => tag.tag_id === tag_id),
               )
             : [];
         setContentTags(
-          defaultTags.filter((tag): tag is Tag => tag !== undefined)
+          defaultTags.filter((tag): tag is Tag => tag !== undefined),
         );
         setAvailableTags(data.filter((tag) => !defaultTags.includes(tag)));
       } catch (error) {
@@ -182,7 +181,6 @@ const ContentBox = ({
     const body: EditContentBody = {
       content_title: content.content_title,
       content_text: content.content_text,
-      content_language: content.content_language,
       content_metadata: content.content_metadata,
       content_tags: content.content_tags,
     };
@@ -219,13 +217,12 @@ const ContentBox = ({
       content_title: "",
       content_text: "",
       content_tags: contentTags.map((tag) => tag!.tag_id),
-      content_language: "ENGLISH",
       content_metadata: {},
     };
   }
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-    key: keyof Content
+    key: keyof Content,
   ) => {
     const emptyContent = createEmptyContent(contentTags);
 
@@ -305,11 +302,11 @@ const ContentBox = ({
                   inputVal &&
                   !availableTags.some(
                     (tag) =>
-                      tag.tag_name.toUpperCase() === inputVal.toUpperCase()
+                      tag.tag_name.toUpperCase() === inputVal.toUpperCase(),
                   ) &&
                   !contentTags.some(
                     (tag) =>
-                      tag.tag_name.toUpperCase() === inputVal.toUpperCase()
+                      tag.tag_name.toUpperCase() === inputVal.toUpperCase(),
                   )
                 ) {
                   event.preventDefault();
@@ -323,11 +320,11 @@ const ContentBox = ({
           const filtered = filter(options, params);
           const { inputValue } = params;
           const isExisting = options.some(
-            (option) => inputValue.toUpperCase() === option.tag_name
+            (option) => inputValue.toUpperCase() === option.tag_name,
           );
 
           const isSelected = contentTags.some(
-            (tag) => inputValue.toUpperCase() === tag.tag_name
+            (tag) => inputValue.toUpperCase() === tag.tag_name,
           );
 
           if (inputValue !== "" && !isExisting && !isSelected) {
@@ -346,11 +343,11 @@ const ContentBox = ({
             option.tag_name &&
             !availableTags.some(
               (tag) =>
-                tag.tag_name.toUpperCase() === option.tag_name.toUpperCase()
+                tag.tag_name.toUpperCase() === option.tag_name.toUpperCase(),
             ) &&
             !contentTags.some(
               (tag) =>
-                tag.tag_name.toUpperCase() === option.tag_name.toUpperCase()
+                tag.tag_name.toUpperCase() === option.tag_name.toUpperCase(),
             )
           ) {
             return (
@@ -443,7 +440,7 @@ const ContentBox = ({
                   if (content_id) {
                     const actionType = content.content_id ? "edit" : "add";
                     router.push(
-                      `/content/?content_id=${content_id}&action=${actionType}`
+                      `/content/?content_id=${content_id}&action=${actionType}`,
                     );
                   }
                 };

--- a/admin_app/src/utils/api.ts
+++ b/admin_app/src/utils/api.ts
@@ -4,7 +4,6 @@ const NEXT_PUBLIC_BACKEND_URL: string =
 interface ContentBody {
   content_title: string;
   content_text: string;
-  content_language: string;
   content_metadata: Record<string, unknown>;
 }
 

--- a/core_backend/app/contents/models.py
+++ b/core_backend/app/contents/models.py
@@ -42,7 +42,6 @@ class ContentDB(Base):
     )
     content_title: Mapped[str] = mapped_column(String(length=150), nullable=False)
     content_text: Mapped[str] = mapped_column(String(length=2000), nullable=False)
-    content_language: Mapped[str] = mapped_column(String, nullable=False)
 
     content_metadata: Mapped[JSONDict] = mapped_column(JSON, nullable=False)
 
@@ -66,7 +65,6 @@ class ContentDB(Base):
             f"content_embedding=..., "
             f"content_title={self.content_title}, "
             f"content_text={self.content_text}, "
-            f"content_language={self.content_language}, "
             f"content_metadata={self.content_metadata}, "
             f"content_tags={self.content_tags}, "
             f"created_datetime_utc={self.created_datetime_utc}, "
@@ -93,7 +91,6 @@ async def save_content_to_db(
         content_embedding=content_embedding,
         content_title=content.content_title,
         content_text=content.content_text,
-        content_language=content.content_language,
         content_metadata=content.content_metadata,
         content_tags=content.content_tags,
         created_datetime_utc=datetime.utcnow(),
@@ -134,7 +131,6 @@ async def update_content_in_db(
         content_embedding=content_embedding,
         content_title=content.content_title,
         content_text=content.content_text,
-        content_language=content.content_language,
         content_metadata=content.content_metadata,
         content_tags=content.content_tags,
         created_datetime_utc=datetime.utcnow(),

--- a/core_backend/app/contents/routers.py
+++ b/core_backend/app/contents/routers.py
@@ -201,7 +201,6 @@ async def bulk_upload_contents(
         content = ContentCreate(
             content_title=row["content_title"],
             content_text=row["content_text"],
-            content_language="ENGLISH",
             content_tags=[],
             content_metadata={},
         )
@@ -385,7 +384,6 @@ def _convert_record_to_schema(record: ContentDB) -> ContentRetrieve:
         user_id=record.user_id,
         content_title=record.content_title,
         content_text=record.content_text,
-        content_language=record.content_language,
         content_tags=[tag.tag_id for tag in record.content_tags],
         positive_votes=record.positive_votes,
         negative_votes=record.negative_votes,

--- a/core_backend/app/contents/schemas.py
+++ b/core_backend/app/contents/schemas.py
@@ -1,9 +1,7 @@
 from datetime import datetime
 from typing import Annotated, List
 
-from pydantic import BaseModel, ConfigDict, StringConstraints, validator
-
-from ..llm_call.llm_prompts import IdentifiedLanguage
+from pydantic import BaseModel, ConfigDict, StringConstraints
 
 
 class ContentCreate(BaseModel):
@@ -14,22 +12,10 @@ class ContentCreate(BaseModel):
     # Ensure len("*{title}*\n\n{text}") <= 1600
     content_title: Annotated[str, StringConstraints(max_length=150)]
     content_text: Annotated[str, StringConstraints(max_length=2000)]
-    content_language: str = "ENGLISH"
     content_tags: list = []
     content_metadata: dict = {}
 
     model_config = ConfigDict(from_attributes=True)
-
-    @validator("content_language")
-    def validate_language(cls, v: str) -> str:
-        """
-        Validator for language
-        """
-
-        if v not in IdentifiedLanguage.get_supported_languages():
-            raise ValueError(f"Language {v} is not supported")
-
-        return v
 
 
 class ContentRetrieve(ContentCreate):

--- a/core_backend/migrations/versions/2024_06_26_7a68f045e8d3_remove_content_language.py
+++ b/core_backend/migrations/versions/2024_06_26_7a68f045e8d3_remove_content_language.py
@@ -1,4 +1,4 @@
-"""empty message
+"""remove content_language
 
 Revision ID: 7a68f045e8d3
 Revises: 29b5ffa97758

--- a/core_backend/migrations/versions/2024_06_26_7a68f045e8d3_remove_content_language.py
+++ b/core_backend/migrations/versions/2024_06_26_7a68f045e8d3_remove_content_language.py
@@ -1,0 +1,27 @@
+"""empty message
+
+Revision ID: 7a68f045e8d3
+Revises: 29b5ffa97758
+Create Date: 2024-06-26 12:41:46.706891
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "7a68f045e8d3"
+down_revision: Union[str, None] = "29b5ffa97758"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_column("content", "content_language")
+
+
+def downgrade() -> None:
+    op.add_column("content", sa.Column("content_language", sa.String(), nullable=False))
+    op.execute("UPDATE content SET content_language = 'ENGLISH'")

--- a/core_backend/migrations/versions/2024_06_26_7a68f045e8d3_remove_content_language.py
+++ b/core_backend/migrations/versions/2024_06_26_7a68f045e8d3_remove_content_language.py
@@ -23,5 +23,6 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.add_column("content", sa.Column("content_language", sa.String(), nullable=False))
+    op.add_column("content", sa.Column("content_language", sa.String(), nullable=True))
     op.execute("UPDATE content SET content_language = 'ENGLISH'")
+    op.alter_column("content", "content_language", nullable=False)

--- a/core_backend/tests/api/conftest.py
+++ b/core_backend/tests/api/conftest.py
@@ -141,7 +141,6 @@ async def faq_contents(client: TestClient, db_session: Session) -> None:
             content_embedding=content_embedding,
             content_title=content["content_title"],
             content_text=content["content_text"],
-            content_language="ENGLISH",
             content_metadata=content.get("content_metadata", {}),
             created_datetime_utc=datetime.utcnow(),
             updated_datetime_utc=datetime.utcnow(),

--- a/core_backend/tests/api/test_import_content.py
+++ b/core_backend/tests/api/test_import_content.py
@@ -183,7 +183,6 @@ class TestDBDuplicates:
             json={
                 "content_title": "Title in DB",
                 "content_text": "Text in DB",
-                "content_language": "ENGLISH",
                 "content_tags": [],
                 "content_metadata": {},
             },

--- a/core_backend/tests/api/test_manage_content.py
+++ b/core_backend/tests/api/test_manage_content.py
@@ -31,7 +31,6 @@ def existing_content_id(
         json={
             "content_title": request.param[0],
             "content_text": request.param[1],
-            "content_language": "ENGLISH",
             "content_tags": [],
             "content_metadata": request.param[2],
         },
@@ -68,7 +67,6 @@ class TestManageContent:
             json={
                 "content_title": content_title,
                 "content_text": content_text,
-                "content_language": "ENGLISH",
                 "content_tags": content_tags,
                 "content_metadata": content_metadata,
             },
@@ -115,7 +113,6 @@ class TestManageContent:
                 "content_title": content_title,
                 "content_text": content_text,
                 "content_tags": [existing_tag_id],
-                "content_language": "ENGLISH",
                 "content_metadata": content_metadata,
             },
         )
@@ -143,7 +140,6 @@ class TestManageContent:
             json={
                 "content_title": "title",
                 "content_text": "sample text",
-                "content_language": "ENGLISH",
                 "content_metadata": {"key": "value"},
             },
         )
@@ -198,7 +194,6 @@ class TestMultUserManageContent:
             json={
                 "content_title": "user2 title 3",
                 "content_text": "user2 test content 3",
-                "content_language": "ENGLISH",
                 "content_metadata": {},
             },
         )
@@ -226,7 +221,6 @@ async def test_convert_record_to_schema() -> None:
         content_title="sample title for content",
         content_text="sample text",
         content_embedding=await async_fake_embedding(),
-        content_language="ENGLISH",
         positive_votes=0,
         negative_votes=0,
         content_metadata={"extra_field": "extra value"},

--- a/core_backend/validation/retrieval/validate_retrieval.py
+++ b/core_backend/validation/retrieval/validate_retrieval.py
@@ -123,7 +123,6 @@ class TestRetrievalPerformance:
                 content_embedding=content_embedding,
                 content_title=content_title,
                 content_text=content_text,
-                content_language="ENGLISH",
                 content_metadata={},
                 created_datetime_utc=datetime.utcnow(),
                 updated_datetime_utc=datetime.utcnow(),

--- a/deployment/docker-compose/docker-compose.dev.yml
+++ b/deployment/docker-compose/docker-compose.dev.yml
@@ -11,6 +11,8 @@ services:
       - .env
     volumes:
       - db_volume:/var/lib/postgresql/data
+    ports:
+      - 5432:5432
 
 volumes:
   db_volume:

--- a/scripts/add_content_to_db.py
+++ b/scripts/add_content_to_db.py
@@ -14,27 +14,20 @@ except ImportError:
 
 parser = argparse.ArgumentParser(
     description="Bulk add content to the database from a CSV file. "
-    "Expects the CSV file to have columns: title, body. (Optionally, language. "
-    "See also the --language option.)",
+    "Expects the CSV file to have columns: title, body.",
     usage="""
-    python add_content_to_db.py [-h] --csv CSV --domain DOMAIN [--language LANGUAGE]
+    python add_content_to_db.py [-h] --csv CSV --domain DOMAIN
 
     (example)
     python add_content_to_db.py \\
         --csv content.csv \\
-        --domain aaq.idinsight.com \\
-        --language ENGLISH
+        --domain aaq.idinsight.com
 """,
 )
 parser.add_argument(
     "--csv", help="Path to the CSV file with columns: title, body", required=True
 )
 parser.add_argument("--domain", help="Your AAQ domain", required=True)
-parser.add_argument(
-    "--language",
-    help="Language of the content, if it is the same for the whole file.",
-    required=False,
-)
 args = parser.parse_args()
 
 
@@ -72,14 +65,9 @@ if __name__ == "__main__":
     with open(args.csv, mode="r", encoding="utf-8") as file:
         reader = csv.DictReader(file)
         for row in reader:
-            if args.language:
-                language = args.language
-            else:
-                language = row["language"]
             payload = {
                 "content_title": row["title"],
                 "content_text": row["body"],
-                "content_language": language,
                 "content_metadata": {},
             }
             response = requests.post(api_endpoint, json=payload, headers=headers)


### PR DESCRIPTION
Reviewer: @amiraliemami
Estimate: 20 min

---

## Ticket

Fixes: https://idinsight.atlassian.net/browse/AAQ-580

## Description

### Goal

Remove unused field content_language

### Changes

- remove content_language in backend and admin app
- remove it from Db upload script
- create migration script

### Future Tasks (optional)

## How has this been tested?
Ran unit tests.

For sanity check:
1. `git switch remove-content-lang`
2. `alembic upgrade ...`
3. `cd deployment/docker-compose`
4. `docker compose ... up --build`
5. check core_backend container startup log -- new migration should have run
6. check DB via pgadmin/postico etc. (localhost:5432) -- content_language column has been dropped
7. `docker compose ... down`
8. `alembic downgrade`
9. `git switch main`
10. `docker compose ... up --build`
11. check core_backend container log -- migrations should have run ok
12. check DB -- content_language column is there, filled with ENGLISH

## To-do before merge (optional)

## Checklist

Fill with `x` for completed. 

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts

- [x] I have updated the automated tests
- [x] I have updated the scripts in `scripts/`
