### PR TITLE
[AAQ-614] Use Vertex AI API in GCP deployment

### DIFF
--- a/.github/workflows/deploy_gcp_admin_app.yaml
+++ b/.github/workflows/deploy_gcp_admin_app.yaml
@@ -19,7 +19,6 @@ jobs:
       contents: "read"
       id-token: "write"
 
-    # TODO: replace improve-gcp-deploy with main
     environment: gcp-${{ (github.ref_name == 'main' && 'testing') || github.ref_name }}
 
     env:

--- a/.github/workflows/deploy_gcp_litellm_proxy.yaml
+++ b/.github/workflows/deploy_gcp_litellm_proxy.yaml
@@ -51,7 +51,7 @@ jobs:
           gcloud compute scp litellm_proxy_config.yaml \
               ${{ secrets.DEPLOYMENT_INSTANCE_NAME }}:~/litellm_proxy_config.yaml \
               --zone ${{ secrets.DEPLOYMENT_ZONE }}
-          echo "${{ secrets.gcp-credential-json }}" > .gcp_credentials.json
+          echo "${{ secrets.outputs.gcp-credential-json }}" > .gcp_credentials.json
           gcloud compute scp .gcp_credentials.json \
               ${{ secrets.DEPLOYMENT_INSTANCE_NAME }}:~/.gcp_credentials.json \
               --zone ${{ secrets.DEPLOYMENT_ZONE }}

--- a/.github/workflows/deploy_gcp_litellm_proxy.yaml
+++ b/.github/workflows/deploy_gcp_litellm_proxy.yaml
@@ -78,7 +78,7 @@ jobs:
               --restart always \
               --network aaq-network \
               --name litellm_proxy \
-              ghcr.io/berriai/litellm:main-v1.34.6 --config /app/config.yaml
+              ghcr.io/berriai/litellm:main-v1.40.10 --config /app/config.yaml
             docker system prune -f
 
       - name: Show deployment command output

--- a/.github/workflows/deploy_gcp_litellm_proxy.yaml
+++ b/.github/workflows/deploy_gcp_litellm_proxy.yaml
@@ -51,7 +51,7 @@ jobs:
           gcloud compute scp litellm_proxy_config.yaml \
               ${{ secrets.DEPLOYMENT_INSTANCE_NAME }}:~/litellm_proxy_config.yaml \
               --zone ${{ secrets.DEPLOYMENT_ZONE }}
-          echo ${{ secrets.gcp-credential-json}} > ~/.gcp_credentials.json
+          echo "${{ secrets.gcp-credential-json }}" > .gcp_credentials.json
           gcloud compute scp .gcp_credentials.json \
               ${{ secrets.DEPLOYMENT_INSTANCE_NAME }}:~/.gcp_credentials.json \
               --zone ${{ secrets.DEPLOYMENT_ZONE }}

--- a/.github/workflows/deploy_gcp_litellm_proxy.yaml
+++ b/.github/workflows/deploy_gcp_litellm_proxy.yaml
@@ -51,7 +51,7 @@ jobs:
           gcloud compute scp litellm_proxy_config.yaml \
               ${{ secrets.DEPLOYMENT_INSTANCE_NAME }}:~/litellm_proxy_config.yaml \
               --zone ${{ secrets.DEPLOYMENT_ZONE }}
-          echo "${{ steps.secrets.outputs.gcp-credential-json }}" > .gcp_credentials.json
+          echo '${{ steps.secrets.outputs.gcp-credential-json }}' > .gcp_credentials.json
           gcloud compute scp .gcp_credentials.json \
               ${{ secrets.DEPLOYMENT_INSTANCE_NAME }}:~/.gcp_credentials.json \
               --zone ${{ secrets.DEPLOYMENT_ZONE }}

--- a/.github/workflows/deploy_gcp_litellm_proxy.yaml
+++ b/.github/workflows/deploy_gcp_litellm_proxy.yaml
@@ -43,6 +43,7 @@ jobs:
           secrets: |-
             domain:${{ secrets.GCP_PROJECT_ID }}/${{ env.RESOURCE_PREFIX }}-domain
             openai-api-key:${{ secrets.GCP_PROJECT_ID }}/${{ env.RESOURCE_PREFIX }}-openai-api-key
+            gcp-credentials:${{ secrets.GCP_PROJECT_ID }}/${{ env.RESOURCE_PREFIX }}-gcp-credential-json
 
       - name: Copy LiteLLM deployment files
         working-directory: deployment/docker-compose
@@ -59,11 +60,21 @@ jobs:
           zone: "${{ secrets.DEPLOYMENT_ZONE }}"
           ssh_private_key: "${{ secrets.GCP_SSH_PRIVATE_KEY }}"
           command: |
+            gcloud secrets versions access latest \
+              --secret=${{ env.RESOURCE_PREFIX }}-gcp-credential-json \
+              --format='get(payload.data)' \
+              | tr '_-' '/+' \
+              | base64 -d \
+              > /app/credentials.json
             docker stop litellm_proxy
             docker rm litellm_proxy
             docker run -d \
               -v ~/litellm_proxy_config.yaml:/app/config.yaml \
               -e OPENAI_API_KEY="${{ steps.secrets.outputs.openai-api-key }}" \
+              -e VERTEXAI_PROJECT=${{ secrets.GCP_PROJECT_ID }} \
+              -e VERTEXAI_LOCATION=${{ vars.VERTEX_AI_LOCATION }} \
+              -e VERTEXAI_ENDPOINT=https://${{ vars.VERTEX_AI_LOCATION }}-aiplatform.googleapis.com/v1 \
+              -e GOOGLE_APPLICATION_CREDENTIALS=/app/credentials.json \
               --log-driver=gcplogs \
               --restart always \
               --network aaq-network \

--- a/.github/workflows/deploy_gcp_litellm_proxy.yaml
+++ b/.github/workflows/deploy_gcp_litellm_proxy.yaml
@@ -51,7 +51,7 @@ jobs:
           gcloud compute scp litellm_proxy_config.yaml \
               ${{ secrets.DEPLOYMENT_INSTANCE_NAME }}:~/litellm_proxy_config.yaml \
               --zone ${{ secrets.DEPLOYMENT_ZONE }}
-          echo "${{ secrets.outputs.gcp-credential-json }}" > .gcp_credentials.json
+          echo "${{ steps.secrets.outputs.gcp-credential-json }}" > .gcp_credentials.json
           gcloud compute scp .gcp_credentials.json \
               ${{ secrets.DEPLOYMENT_INSTANCE_NAME }}:~/.gcp_credentials.json \
               --zone ${{ secrets.DEPLOYMENT_ZONE }}

--- a/.github/workflows/deploy_gcp_litellm_proxy.yaml
+++ b/.github/workflows/deploy_gcp_litellm_proxy.yaml
@@ -43,12 +43,17 @@ jobs:
           secrets: |-
             domain:${{ secrets.GCP_PROJECT_ID }}/${{ env.RESOURCE_PREFIX }}-domain
             openai-api-key:${{ secrets.GCP_PROJECT_ID }}/${{ env.RESOURCE_PREFIX }}-openai-api-key
+            gcp-credential-json:${{ secrets.GCP_PROJECT_ID }}/${{ env.RESOURCE_PREFIX }}-gcp-credential-json
 
       - name: Copy LiteLLM deployment files
         working-directory: deployment/docker-compose
         run: |
           gcloud compute scp litellm_proxy_config.yaml \
               ${{ secrets.DEPLOYMENT_INSTANCE_NAME }}:~/litellm_proxy_config.yaml \
+              --zone ${{ secrets.DEPLOYMENT_ZONE }}
+          echo ${{ secrets.gcp-credential-json}} > ~/.gcp_credentials.json
+          gcloud compute scp .gcp_credentials.json \
+              ${{ secrets.DEPLOYMENT_INSTANCE_NAME }}:~/.gcp_credentials.json \
               --zone ${{ secrets.DEPLOYMENT_ZONE }}
 
       - name: Deploy LiteLLM Proxy container
@@ -59,16 +64,11 @@ jobs:
           zone: "${{ secrets.DEPLOYMENT_ZONE }}"
           ssh_private_key: "${{ secrets.GCP_SSH_PRIVATE_KEY }}"
           command: |
-            gcloud secrets versions access latest \
-              --secret=${{ env.RESOURCE_PREFIX }}-gcp-credential-json \
-              --format='get(payload.data)' \
-              | tr '_-' '/+' \
-              | base64 -d \
-              > /app/credentials.json
             docker stop litellm_proxy
             docker rm litellm_proxy
             docker run -d \
               -v ~/litellm_proxy_config.yaml:/app/config.yaml \
+              -v ~/.gcp_credentials.json:/app/credentials.json \
               -e OPENAI_API_KEY="${{ steps.secrets.outputs.openai-api-key }}" \
               -e VERTEXAI_PROJECT=${{ secrets.GCP_PROJECT_ID }} \
               -e VERTEXAI_LOCATION=${{ vars.VERTEX_AI_LOCATION }} \

--- a/.github/workflows/deploy_gcp_litellm_proxy.yaml
+++ b/.github/workflows/deploy_gcp_litellm_proxy.yaml
@@ -43,7 +43,6 @@ jobs:
           secrets: |-
             domain:${{ secrets.GCP_PROJECT_ID }}/${{ env.RESOURCE_PREFIX }}-domain
             openai-api-key:${{ secrets.GCP_PROJECT_ID }}/${{ env.RESOURCE_PREFIX }}-openai-api-key
-            gcp-credentials:${{ secrets.GCP_PROJECT_ID }}/${{ env.RESOURCE_PREFIX }}-gcp-credential-json
 
       - name: Copy LiteLLM deployment files
         working-directory: deployment/docker-compose

--- a/.gitignore
+++ b/.gitignore
@@ -142,6 +142,7 @@ dmypy.json
 # Secrets
 *secrets*
 .pgpass
+**/*credentials.json
 
 # Mac artifacts and temp files
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -66,10 +66,14 @@ setup-llm-proxy:
 		--name litellm-proxy \
 		--rm \
 		-v "$(CURDIR)/deployment/docker-compose/litellm_proxy_config.yaml":/app/config.yaml \
+		-v "$(CURDIR)/deployment/docker-compose/.gcp_credentials.json":/app/credentials.json \
 		-e OPENAI_API_KEY=$(OPENAI_API_KEY) \
-		-e GEMINI_API_KEY=$(GEMINI_API_KEY) \
 		-e EMBEDDINGS_API_KEY=$(EMBEDDINGS_API_KEY) \
 		-e EMBEDDINGS_ENDPOINT=$(EMBEDDINGS_ENDPOINT) \
+		-e VERTEXAI_PROJECT=$(VERTEXAI_PROJECT) \
+		-e VERTEXAI_LOCATION=$(VERTEXAI_LOCATION) \
+		-e VERTEXAI_ENDPOINT=https://$(VERTEXAI_LOCATION)-aiplatform.googleapis.com/v1 \
+		-e GOOGLE_APPLICATION_CREDENTIALS=/app/credentials.json \
 		-p 4000:4000 \
 		-d ghcr.io/berriai/litellm:main-v1.40.10 \
 		--config /app/config.yaml --detailed_debug

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ setup-llm-proxy:
 	-@docker rm litellm-proxy
 	@docker system prune -f
 	@sleep 2
-	@docker pull ghcr.io/berriai/litellm:main-v1.34.6
+	@docker pull ghcr.io/berriai/litellm:main-v1.40.10
 	@docker run \
 		--name litellm-proxy \
 		--rm \
@@ -71,7 +71,7 @@ setup-llm-proxy:
 		-e EMBEDDINGS_API_KEY=$(EMBEDDINGS_API_KEY) \
 		-e EMBEDDINGS_ENDPOINT=$(EMBEDDINGS_ENDPOINT) \
 		-p 4000:4000 \
-		-d ghcr.io/berriai/litellm:main-v1.34.6 \
+		-d ghcr.io/berriai/litellm:main-v1.40.10 \
 		--config /app/config.yaml --detailed_debug
 
 teardown-llm-proxy:

--- a/core_backend/app/config.py
+++ b/core_backend/app/config.py
@@ -26,7 +26,7 @@ LITELLM_MODEL_EMBEDDING = os.environ.get("LITELLM_MODEL_EMBEDDING", "openai/embe
 LITELLM_MODEL_DEFAULT = os.environ.get("LITELLM_MODEL_DEFAULT", "openai/default")
 LITELLM_MODEL_GENERATION = os.environ.get(
     "LITELLM_MODEL_GENERATION",
-    "generate-gemini-response",
+    "vertex_ai_beta/generate-gemini-response",
     # "LITELLM_MODEL_GENERATION", "openai/generate-response"
 )
 LITELLM_MODEL_LANGUAGE_DETECT = os.environ.get(

--- a/core_backend/app/config.py
+++ b/core_backend/app/config.py
@@ -25,7 +25,9 @@ LITELLM_API_KEY = os.environ.get("LITELLM_API_KEY", "dummy-key")
 LITELLM_MODEL_EMBEDDING = os.environ.get("LITELLM_MODEL_EMBEDDING", "openai/embeddings")
 LITELLM_MODEL_DEFAULT = os.environ.get("LITELLM_MODEL_DEFAULT", "openai/default")
 LITELLM_MODEL_GENERATION = os.environ.get(
-    "LITELLM_MODEL_GENERATION", "openai/generate-response"
+    "LITELLM_MODEL_GENERATION",
+    "generate-gemini-response",
+    # "LITELLM_MODEL_GENERATION", "openai/generate-response"
 )
 LITELLM_MODEL_LANGUAGE_DETECT = os.environ.get(
     "LITELLM_MODEL_LANGUAGE_DETECT", "openai/detect-language"

--- a/core_backend/app/config.py
+++ b/core_backend/app/config.py
@@ -26,7 +26,7 @@ LITELLM_MODEL_EMBEDDING = os.environ.get("LITELLM_MODEL_EMBEDDING", "openai/embe
 LITELLM_MODEL_DEFAULT = os.environ.get("LITELLM_MODEL_DEFAULT", "openai/default")
 LITELLM_MODEL_GENERATION = os.environ.get(
     "LITELLM_MODEL_GENERATION",
-    "vertex_ai_beta/generate-gemini-response",
+    "openai/generate-gemini-response",
     # "LITELLM_MODEL_GENERATION", "openai/generate-response"
 )
 LITELLM_MODEL_LANGUAGE_DETECT = os.environ.get(

--- a/deployment/docker-compose/docker-compose.yml
+++ b/deployment/docker-compose/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - .env
 
   litellm_proxy:
-    image: ghcr.io/berriai/litellm:main-v1.41.2
+    image: ghcr.io/berriai/litellm:main-v1.41.3
     restart: always
     env_file:
       - .env

--- a/deployment/docker-compose/docker-compose.yml
+++ b/deployment/docker-compose/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - .env
 
   litellm_proxy:
-    image: ghcr.io/berriai/litellm:main-v1.34.6
+    image: ghcr.io/berriai/litellm:main-v1.41.2
     restart: always
     env_file:
       - .env

--- a/deployment/docker-compose/docker-compose.yml
+++ b/deployment/docker-compose/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - .env
 
   litellm_proxy:
-    image: ghcr.io/berriai/litellm:main-v1.41.3
+    image: ghcr.io/berriai/litellm:main-v1.40.10
     restart: always
     env_file:
       - .env

--- a/deployment/docker-compose/docker-compose.yml
+++ b/deployment/docker-compose/docker-compose.yml
@@ -55,6 +55,7 @@ services:
       - .env
     volumes:
       - ./litellm_proxy_config.yaml:/app/config.yaml
+      - ./.gcp_credentials.json:/app/credentials.json
     command:
       ["--config", "/app/config.yaml", "--port", "4000", "--num_workers", "1"]
 

--- a/deployment/docker-compose/litellm_proxy_config.yaml
+++ b/deployment/docker-compose/litellm_proxy_config.yaml
@@ -18,7 +18,7 @@ model_list:
       api_key: "os.environ/OPENAI_API_KEY"
   - model_name: generate-gemini-response
     litellm_params:
-      model: vertex_ai_beta/gemini-1.5-pro-latest
+      model: vertex_ai/gemini-1.5-pro-latest
       safety_settings:
         - category: HARM_CATEGORY_HARASSMENT
           threshold: BLOCK_NONE

--- a/deployment/docker-compose/litellm_proxy_config.yaml
+++ b/deployment/docker-compose/litellm_proxy_config.yaml
@@ -54,6 +54,20 @@ model_list:
     litellm_params:
       model: gpt-4o
       api_key: "os.environ/OPENAI_API_KEY"
+  - model_name: alignscore-gemini
+    litellm_params:
+      # Set VERTEXAI_ENDPOINT environment variable or direclty enter the value:
+      api_base: "os.environ/VERTEXAI_ENDPOINT"
+      model: vertex_ai/gemini-1.5-pro
+      safety_settings:
+        - category: HARM_CATEGORY_HARASSMENT
+          threshold: BLOCK_ONLY_HIGH
+        - category: HARM_CATEGORY_HATE_SPEECH
+          threshold: BLOCK_ONLY_HIGH
+        - category: HARM_CATEGORY_SEXUALLY_EXPLICIT
+          threshold: BLOCK_ONLY_HIGH
+        - category: HARM_CATEGORY_DANGEROUS_CONTENT
+          threshold: BLOCK_ONLY_HIGH
   - model_name: urgency-detection
     litellm_params:
       model: gpt-3.5-turbo-1106

--- a/deployment/docker-compose/litellm_proxy_config.yaml
+++ b/deployment/docker-compose/litellm_proxy_config.yaml
@@ -56,7 +56,7 @@ model_list:
       api_key: "os.environ/OPENAI_API_KEY"
   - model_name: alignscore-gemini
     litellm_params:
-      # Set VERTEXAI_ENDPOINT environment variable or direclty enter the value:
+      # Set VERTEXAI_ENDPOINT environment variable or directly enter the value:
       api_base: "os.environ/VERTEXAI_ENDPOINT"
       model: vertex_ai/gemini-1.5-pro
       safety_settings:

--- a/deployment/docker-compose/litellm_proxy_config.yaml
+++ b/deployment/docker-compose/litellm_proxy_config.yaml
@@ -16,17 +16,18 @@ model_list:
     litellm_params:
       model: gpt-4o
       api_key: "os.environ/OPENAI_API_KEY"
-      # model: gemini/gemini-1.5-pro-latest
-      # api_key: "os.environ/GEMINI_API_KEY"
-      # safety_settings:
-      #   - category: HARM_CATEGORY_HARASSMENT
-      #     threshold: BLOCK_NONE
-      #   - category: HARM_CATEGORY_HATE_SPEECH
-      #     threshold: BLOCK_NONE
-      #   - category: HARM_CATEGORY_SEXUALLY_EXPLICIT
-      #     threshold: BLOCK_NONE
-      #   - category: HARM_CATEGORY_DANGEROUS_CONTENT
-      #     threshold: BLOCK_NONE
+  - model_name: generate-gemini-response
+    litellm_params:
+      model: vertex_ai_beta/gemini-1.5-pro-latest
+      safety_settings:
+        - category: HARM_CATEGORY_HARASSMENT
+          threshold: BLOCK_NONE
+        - category: HARM_CATEGORY_HATE_SPEECH
+          threshold: BLOCK_NONE
+        - category: HARM_CATEGORY_SEXUALLY_EXPLICIT
+          threshold: BLOCK_NONE
+        - category: HARM_CATEGORY_DANGEROUS_CONTENT
+          threshold: BLOCK_NONE
   - model_name: detect-language
     litellm_params:
       model: gpt-4o
@@ -60,3 +61,5 @@ litellm_settings:
   request_timeout: 100 # raise Timeout error if call takes longer than 10s. Sets litellm.request_timeout
   # fallbacks: [{"paraphrase": ["default"]}] # fallback to default model if paraphrase model fails num_retries
   telemetry: False
+  vertex_project: ${GCP_PROJECT_ID}
+  vertex_location: ${GCP_PROJECT_ZONE}

--- a/deployment/docker-compose/litellm_proxy_config.yaml
+++ b/deployment/docker-compose/litellm_proxy_config.yaml
@@ -18,7 +18,7 @@ model_list:
       api_key: "os.environ/OPENAI_API_KEY"
   - model_name: generate-gemini-response
     litellm_params:
-      model: vertex_ai/gemini-1.5-pro-latest
+      model: vertex_ai_beta/gemini-1.5-pro-latest
       safety_settings:
         - category: HARM_CATEGORY_HARASSMENT
           threshold: BLOCK_NONE

--- a/deployment/docker-compose/litellm_proxy_config.yaml
+++ b/deployment/docker-compose/litellm_proxy_config.yaml
@@ -18,16 +18,18 @@ model_list:
       api_key: "os.environ/OPENAI_API_KEY"
   - model_name: generate-gemini-response
     litellm_params:
-      model: vertex_ai/gemini-1.5-pro-latest
+      # Set VERTEXAI_ENDPOINT environment variable or direclty enter the value:
+      api_base: "os.environ/VERTEXAI_ENDPOINT"
+      model: vertex_ai/gemini-1.5-pro
       safety_settings:
         - category: HARM_CATEGORY_HARASSMENT
-          threshold: BLOCK_NONE
+          threshold: BLOCK_ONLY_HIGH
         - category: HARM_CATEGORY_HATE_SPEECH
-          threshold: BLOCK_NONE
+          threshold: BLOCK_ONLY_HIGH
         - category: HARM_CATEGORY_SEXUALLY_EXPLICIT
-          threshold: BLOCK_NONE
+          threshold: BLOCK_ONLY_HIGH
         - category: HARM_CATEGORY_DANGEROUS_CONTENT
-          threshold: BLOCK_NONE
+          threshold: BLOCK_ONLY_HIGH
   - model_name: detect-language
     litellm_params:
       model: gpt-4o
@@ -61,5 +63,6 @@ litellm_settings:
   request_timeout: 100 # raise Timeout error if call takes longer than 10s. Sets litellm.request_timeout
   # fallbacks: [{"paraphrase": ["default"]}] # fallback to default model if paraphrase model fails num_retries
   telemetry: False
-  vertex_project: ${GCP_PROJECT_ID}
-  vertex_location: ${GCP_PROJECT_ZONE}
+  # To use Vertex AI API, uncomment the following lines:
+  # vertex_project: gcp-project-id-12345
+  # vertex_location: us-central1

--- a/deployment/docker-compose/litellm_proxy_config.yaml
+++ b/deployment/docker-compose/litellm_proxy_config.yaml
@@ -18,7 +18,7 @@ model_list:
       api_key: "os.environ/OPENAI_API_KEY"
   - model_name: generate-gemini-response
     litellm_params:
-      # Set VERTEXAI_ENDPOINT environment variable or direclty enter the value:
+      # Set VERTEXAI_ENDPOINT environment variable or directly enter the value:
       api_base: "os.environ/VERTEXAI_ENDPOINT"
       model: vertex_ai/gemini-1.5-pro
       safety_settings:

--- a/deployment/docker-compose/template.env
+++ b/deployment/docker-compose/template.env
@@ -25,14 +25,6 @@ JWT_SECRET="jwt-secret"
 # N_TOP_CONTENT_FOR_SEARCH=
 # N_TOP_CONTENT_FOR_RAG=
 
-#### Variables for LiteLLM Proxy
-OPENAI_API_KEY="sk-..."
-GEMINI_API_KEY="..."
-UI_USERNAME="admin"
-UI_PASSWORD="admin"
-# endpoint for the backend to call - must be set to the internal service name and port
-LITELLM_ENDPOINT="http://litellm_proxy:4000"
-
 ### limits
 # CHECK_CONTENT_LIMIT=True
 # DEFAULT_CONTENT_QUOTA=50
@@ -51,6 +43,8 @@ NEXT_PUBLIC_BACKEND_URL="https://localhost/api"
 HUGGINGFACE_MODEL="thenlper/gte-large"
 EMBEDDINGS_ENDPOINT="http://embeddings:8080"
 EMBEDDINGS_API_KEY="embeddings"
+# endpoint for the backend to call - must be set to the internal service name and port
+LITELLM_ENDPOINT="http://litellm_proxy:4000"
 
 # Temporary folder for prometheus gunicorn multiprocess
 PROMETHEUS_MULTIPROC_DIR="/tmp"
@@ -74,3 +68,15 @@ LANGFUSE=False
 # LANGFUSE_SECRET_KEY="sk-..."
 # optional based on your Langfuse host
 # LANGFUSE_HOST="https://cloud.langfuse.com"
+
+# Variables for LiteLLM Proxy container #######################################
+# If using OpenAI APIs
+OPENAI_API_KEY="sk-..."
+# If using Vertex AI APIs
+GOOGLE_APPLICATION_CREDENTIALS="/path/to/.gcp-credentials.json"
+VERTEXAI_PROJECT="gcp-project-id-12345"
+VERTEXAI_LOCATION="us-central1"
+VERTEXAI_ENDPOINT="https://us-central1-aiplatform.googleapis.com"
+# LiteLLM Proxy UI
+UI_USERNAME="admin"
+UI_PASSWORD="admin"


### PR DESCRIPTION
Reviewer: @amiraliemami 
Estimate: 1hr

---

## Ticket

Fixes: https://idinsight.atlassian.net/browse/AAQ-614

## Description

Incorporate Vertex AI authentication to GCP deployment

Built off of @kristini-ho 's work 🙇 

### Goal

1. Authenticate to Vertex AI from within LiteLLM Proxy
2. Load/set all necessary secrets in CI/CD

### Changes

Instead of an API key, we have:

**Change 1.** Credentials JSON file is saved in LiteLLM Proxy container

**Change 2.** New environment variables are set in LiteLLM Proxy 

1. `GOOGLE_APPLICATION_CREDENTIALS`: Path to credentials key JSON file within LiteLLM Proxy container ([LiteLLM docs link](https://litellm.vercel.app/docs/providers/vertex#pre-requisites))
2. `VERTEXAI_PROJECT`: GCP project ID. ([LiteLLM docs link](https://litellm.vercel.app/docs/providers/vertex#set-vertex-project--vertex-location))
3. `VERTEXAI_LOCATION`: GCP location, e.g. `us-central1`.  ([LiteLLM docs link](https://litellm.vercel.app/docs/providers/vertex#set-vertex-project--vertex-location))
4. `VERTEXAI_ENDPOINT`: API endpoint, e.g. `https://us-central1-aiplatform.googleapis.com`

The information for 2 & 3 can be set via `litellm_proxy_config.yaml`, but I opted for environment variables so we can set them using Secret Manager.

- Added to `deployment/docker-container/template.env`
- Added to custom LiteLLM Proxy Dockerfile `deployment/docker-container/litellm_proxy/Dockerfile`

**Change 3.** Use Gemini for generation
1. In the `litellm_proxy_config.yaml`, I have created a new model called `generate-gemini-response`
2. In `core_backend/app/config.py` I have set the default `LITELLM_MODEL_GENERATION` value to be `generate-gemini-response`


## How has this been tested?

### Local testing
Locally, download the service account key file into `deployment/docker-compose/litellm_proxy/.gcp_credentials.json` (contact @suzinyou ). 

Set new environment variables for litellm_proxy container (or alternatively bake them into the `litellm_proxy_config.yaml`). See template.env for details.
```
VERTEXAI_PROJECT=
VERTEXAI_LOCATION=
VERTEXAI_ENDPOINT=
```
and run docker compose.

### CI/CD testing

Merge this branch to `testing` environment to deploy it on our testing server.

## To-do before merge (optional)

- [x] Merge #264 
- [x] Change the base of this PR to `main`

## Checklist

Fill with `x` for completed. 

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts

(Delete any items below that are not relevant)
- [ ] I have updated the automated tests
- [ ] I have updated the scripts in `scripts/`
- [ ] I have updated the requirements
- [ ] I have updated the README file
- [ ] I have updated affected documentation
- [ ] I have added a blogpost in Latest Updates
- [x] I have updated the CI/CD scripts in `.github/workflows/`

#### [For future reference] How to get credential file

1. Create/identify a service account with owner* role. You can add/edit roles in IAM & Admin console.
2. Obtain key by going to IAM -> Service Accounts -> Select your service account -> Keys tab -> ADD KEY -> Create key, and download the json file.
3. Upload the json as a secret in Secret Manager
5. In cloudbuild_litellm_proxy.yaml, create new step to download the credentials file into container image.
6. Pass additional environment as build args (GCP location, project ID, etc.) --> all required env vars are baked into LiteLLM proxy custom image.

*LiteLLM [documentation suggests](https://litellm.vercel.app/docs/providers/vertex#using-gcp-service-account) that the service account only needs the Vertex AI User role, but @kristini-ho identified that we actually needed the Owner role. We'll follow up with Google.

### Future Tasks (optional)

- Instead of using the credentials file, use the service account attached to our GCP resource (see decision chart for authentication method [here](https://cloud.google.com/docs/authentication#auth-decision-tree))
- Use Gemini for guardrails as well. Why can't we just yet? Gemini APIs have safety filters. By default (a recent change) it doesn't allow us to use the "BLOCK_NONE". This clashes with our own safety filtres and guardrails. See: (How to configure the safety filter)[https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/configure-safety-attributes#how_to_configure_the_safety_filter] -- we'll update once we can get on allowlist
