### PR TITLE
[AAQ-577] Playground feedback

### DIFF
--- a/admin_app/src/app/integrations/components/ChatManagerCard.tsx
+++ b/admin_app/src/app/integrations/components/ChatManagerCard.tsx
@@ -12,6 +12,7 @@ const ChatManagerCard: React.FC<ChatManagerCardInfo> = ({ logo_src, name }) => (
       justifyContent: "center",
       alignItems: "center",
       display: "flex",
+      cursor: "pointer",
     }}
   >
     <CardContent

--- a/admin_app/src/app/playground/components/PlaygroundComponents.tsx
+++ b/admin_app/src/app/playground/components/PlaygroundComponents.tsx
@@ -28,6 +28,7 @@ import ThumbUpAltIcon from "@mui/icons-material/ThumbUpAlt";
 import ThumbUpOffAltIcon from "@mui/icons-material/ThumbUpOffAlt";
 import ThumbDownAltIcon from "@mui/icons-material/ThumbDownAlt";
 import ThumbDownOffAltIcon from "@mui/icons-material/ThumbDownOffAlt";
+import { Feedback } from "@mui/icons-material";
 
 type QueryType = "embeddings-search" | "llm-response" | "urgency-detection";
 
@@ -233,15 +234,19 @@ const MessageSkeleton = () => {
   );
 };
 
-const MessageBox = (
-  message: Message,
+const MessageBox = ({
+  message,
+  onFeedbackSend,
+}: {
+  message: Message;
   onFeedbackSend: (
-    queryID: number,
+    message: ResponseMessage,
     feedbackSentiment: FeedbackSentimentType,
-    feedbackSecretKey: string,
-  ) => void,
-) => {
+  ) => void;
+}) => {
   const [open, setOpen] = useState(false);
+  const [thumbsUp, setThumbsUp] = useState(false);
+  const [thumbsDown, setThumbsDown] = useState(false);
 
   const renderResults = (content: ResponseSummary[]) => {
     return content.map((c: ResponseSummary) => (
@@ -253,6 +258,38 @@ const MessageBox = (
       </Box>
     ));
   };
+  const handlePositiveFeedback = (
+    event: React.MouseEvent<HTMLButtonElement>,
+  ) => {
+    if (thumbsUp) {
+      console.log("Already sent positive feedback");
+    } else {
+      setThumbsUp(true);
+      return onFeedbackSend(
+        message as ResponseMessage,
+        "positive" as FeedbackSentimentType,
+      );
+    }
+  };
+  const handleNegativeFeedback = (
+    event: React.MouseEvent<HTMLButtonElement>,
+  ) => {
+    if (thumbsDown) {
+      console.log("Already sent negative feedback");
+    } else {
+      setThumbsDown(true);
+      return onFeedbackSend(
+        message as ResponseMessage,
+        "negative" as FeedbackSentimentType,
+      );
+    }
+  };
+  const feedbackButtonStyle = {
+    background: "none",
+    border: "none",
+    cursor: "pointer",
+  };
+
   const toggleJsonModal = () => setOpen(!open);
   const modalStyle = {
     position: "absolute",
@@ -268,6 +305,7 @@ const MessageBox = (
     overflow: "scroll",
     borderRadius: "10px",
   };
+
   return (
     <Box
       sx={{
@@ -329,44 +367,32 @@ const MessageBox = (
               marginTop: "5px",
               display: "flex",
               justifyContent: "flex-end",
+              alignItems: "center",
             }}
           >
             {message.json.hasOwnProperty("feedback_secret_key") && (
-              <Box>
+              <Box sx={{ marginRight: "8px" }}>
                 <IconButton
                   aria-label="thumbs up"
-                  onClick={() =>
-                    onFeedbackSend(
-                      message.json["query_id"],
-                      "positive",
-                      message.json["feedback_secret_key"],
-                    )
-                  }
-                  style={{
-                    marginRight: "10px",
-                    background: "none",
-                    border: "none",
-                    cursor: "pointer",
-                  }}
+                  onClick={handlePositiveFeedback}
+                  style={feedbackButtonStyle}
                 >
-                  <ThumbUpAltIcon />
+                  {thumbsUp ? (
+                    <ThumbUpAltIcon fontSize="small" />
+                  ) : (
+                    <ThumbUpOffAltIcon fontSize="small" />
+                  )}
                 </IconButton>
                 <IconButton
                   aria-label="thumbs down"
-                  onClick={() =>
-                    onFeedbackSend(
-                      message.json["query_id"],
-                      "negative",
-                      message.json["feedback_secret_key"],
-                    )
-                  }
-                  style={{
-                    background: "none",
-                    border: "none",
-                    cursor: "pointer",
-                  }}
+                  onClick={handleNegativeFeedback}
+                  style={feedbackButtonStyle}
                 >
-                  <ThumbDownAltIcon />
+                  {thumbsDown ? (
+                    <ThumbDownAltIcon fontSize="small" />
+                  ) : (
+                    <ThumbDownOffAltIcon fontSize="small" />
+                  )}
                 </IconButton>
               </Box>
             )}

--- a/admin_app/src/app/playground/components/PlaygroundComponents.tsx
+++ b/admin_app/src/app/playground/components/PlaygroundComponents.tsx
@@ -205,7 +205,7 @@ const FeedbackButtons = () => {
 
   return (
     <div
-      style={{ marginTop: "10px", display: "flex", justifyContent: "flex-end" }}
+      style={{ marginTop: "5px", display: "flex", justifyContent: "flex-end" }}
     >
       <IconButton
         aria-label="thumbs up"

--- a/admin_app/src/app/playground/components/PlaygroundComponents.tsx
+++ b/admin_app/src/app/playground/components/PlaygroundComponents.tsx
@@ -24,6 +24,9 @@ import PersonIcon from "@mui/icons-material/Person";
 import SendIcon from "@mui/icons-material/Send";
 import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
 import TextField from "@mui/material/TextField";
+import ThumbUp from "@mui/icons-material/ThumbUp";
+import ThumbDown from "@mui/icons-material/ThumbDown";
+import { ThumbUpOffAlt } from "@mui/icons-material";
 
 type QueryType = "embeddings-search" | "llm-response" | "urgency-detection";
 
@@ -189,6 +192,21 @@ const TypingAnimation = () => {
   );
 };
 
+// Feedback buttons
+const FeedbackButtons = () => (
+  <div style={{ marginTop: "10px" }}>
+    <button onClick={() => console.log("Thumbs up clicked")}>
+      <ThumbUp />
+    </button>
+    <button
+      onClick={() => console.log("Thumbs down clicked")}
+      style={{ marginLeft: "5px" }}
+    >
+      <ThumbDown />
+    </button>
+  </div>
+);
+
 const MessageSkeleton = () => {
   return (
     <Box
@@ -311,16 +329,16 @@ const MessageBox = (message: Message) => {
             : renderResults(message.content)}
         </Typography>
         {message.hasOwnProperty("json") && (
-          <Link
-            onClick={toggleJsonModal}
-            variant="caption"
-            align="right"
-            underline="hover"
-            sx={{ cursor: "pointer" }}
-          >
-            {"<json>"}
-          </Link>
-        )}
+            <Link
+              onClick={toggleJsonModal}
+              variant="caption"
+              align="right"
+              underline="hover"
+              sx={{ cursor: "pointer" }}
+            >
+              {"<json>"}
+            </Link>
+          ) && <FeedbackButtons />}
       </Box>
 
       <Modal

--- a/admin_app/src/app/playground/components/PlaygroundComponents.tsx
+++ b/admin_app/src/app/playground/components/PlaygroundComponents.tsx
@@ -24,11 +24,14 @@ import PersonIcon from "@mui/icons-material/Person";
 import SendIcon from "@mui/icons-material/Send";
 import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
 import TextField from "@mui/material/TextField";
-import ThumbUp from "@mui/icons-material/ThumbUp";
-import ThumbDown from "@mui/icons-material/ThumbDown";
-import { ThumbUpOffAlt } from "@mui/icons-material";
+import ThumbUpAltIcon from "@mui/icons-material/ThumbUpAlt";
+import ThumbUpOffAltIcon from "@mui/icons-material/ThumbUpOffAlt";
+import ThumbDownAltIcon from "@mui/icons-material/ThumbDownAlt";
+import ThumbDownOffAltIcon from "@mui/icons-material/ThumbDownOffAlt";
 
 type QueryType = "embeddings-search" | "llm-response" | "urgency-detection";
+
+type FeedbackType = "positive" | "negative";
 
 interface ResponseSummary {
   index: string;
@@ -193,19 +196,39 @@ const TypingAnimation = () => {
 };
 
 // Feedback buttons
-const FeedbackButtons = () => (
-  <div style={{ marginTop: "10px" }}>
-    <button onClick={() => console.log("Thumbs up clicked")}>
-      <ThumbUp />
-    </button>
-    <button
-      onClick={() => console.log("Thumbs down clicked")}
-      style={{ marginLeft: "5px" }}
+const FeedbackButtons = () => {
+  const [isThumbsUpActive, setIsThumbsUpActive] = useState(false);
+  const [isThumbsDownActive, setIsThumbsDownActive] = useState(false);
+
+  const toggleThumbsUp = () => setIsThumbsUpActive(!isThumbsUpActive);
+  const toggleThumbsDown = () => setIsThumbsDownActive(!isThumbsDownActive);
+
+  return (
+    <div
+      style={{ marginTop: "10px", display: "flex", justifyContent: "flex-end" }}
     >
-      <ThumbDown />
-    </button>
-  </div>
-);
+      <IconButton
+        aria-label="thumbs up"
+        onClick={toggleThumbsUp}
+        style={{
+          marginRight: "10px",
+          background: "none",
+          border: "none",
+          cursor: "pointer",
+        }}
+      >
+        {isThumbsUpActive ? <ThumbUpAltIcon /> : <ThumbUpOffAltIcon />}
+      </IconButton>
+      <IconButton
+        aria-label="thumbs down"
+        onClick={toggleThumbsDown}
+        style={{ background: "none", border: "none", cursor: "pointer" }}
+      >
+        {isThumbsDownActive ? <ThumbDownAltIcon /> : <ThumbDownOffAltIcon />}
+      </IconButton>
+    </div>
+  );
+};
 
 const MessageSkeleton = () => {
   return (
@@ -329,16 +352,17 @@ const MessageBox = (message: Message) => {
             : renderResults(message.content)}
         </Typography>
         {message.hasOwnProperty("json") && (
-            <Link
-              onClick={toggleJsonModal}
-              variant="caption"
-              align="right"
-              underline="hover"
-              sx={{ cursor: "pointer" }}
-            >
-              {"<json>"}
-            </Link>
-          ) && <FeedbackButtons />}
+          <Link
+            onClick={toggleJsonModal}
+            variant="caption"
+            align="right"
+            underline="hover"
+            sx={{ cursor: "pointer" }}
+          >
+            {"<json>"}
+          </Link>
+        )}
+        {message.type === "response" && <FeedbackButtons />}
       </Box>
 
       <Modal

--- a/admin_app/src/app/playground/components/PlaygroundComponents.tsx
+++ b/admin_app/src/app/playground/components/PlaygroundComponents.tsx
@@ -28,7 +28,6 @@ import ThumbUpAltIcon from "@mui/icons-material/ThumbUpAlt";
 import ThumbUpOffAltIcon from "@mui/icons-material/ThumbUpOffAlt";
 import ThumbDownAltIcon from "@mui/icons-material/ThumbDownAlt";
 import ThumbDownOffAltIcon from "@mui/icons-material/ThumbDownOffAlt";
-import { Feedback } from "@mui/icons-material";
 
 type QueryType = "embeddings-search" | "llm-response" | "urgency-detection";
 

--- a/admin_app/src/app/playground/page.tsx
+++ b/admin_app/src/app/playground/page.tsx
@@ -236,9 +236,6 @@ const Page = () => {
         .catch((error: Error) => {
           setError("Failed to send response feedback.");
           console.error(error);
-        })
-        .finally(() => {
-          // Any final logic
         });
     }
   };
@@ -252,7 +249,7 @@ const Page = () => {
     }
     setError(null);
   };
-  
+
   return (
     <>
       <Global

--- a/admin_app/src/app/playground/page.tsx
+++ b/admin_app/src/app/playground/page.tsx
@@ -12,6 +12,7 @@ import {
   MessageSkeleton,
   PersistentSearchBar,
   QueryType,
+  FeedbackSentimentType,
   ResponseSummary,
   UserMessage,
 } from "./components/PlaygroundComponents";
@@ -202,6 +203,37 @@ const Page = () => {
       }
     }
   };
+
+  const onFeedbackSend = (
+    query_id: number,
+    feedback_sentiment: FeedbackSentimentType,
+    feedback_secret_key: string,
+  ) => {
+    if (token) {
+      apiCalls
+        .postResponseFeedback(
+          query_id,
+          feedback_sentiment,
+          feedback_secret_key,
+          token,
+        )
+        .then((response) => {
+          if (response.status === 200) {
+            console.log("Feedback sent successfully");
+          } else {
+            console.error(response);
+          }
+        })
+        .catch((error: Error) => {
+          setError("Failed to send response feedback.");
+          console.error(error);
+        })
+        .finally(() => {
+          // Any final logic
+        });
+    }
+  };
+
   const handleErrorClose = (
     event?: React.SyntheticEvent | Event,
     reason?: string,
@@ -211,6 +243,7 @@ const Page = () => {
     }
     setError(null);
   };
+  
   return (
     <>
       <Global
@@ -237,7 +270,11 @@ const Page = () => {
           }}
         >
           {messages.map((message, index) => (
-            <MessageBox key={index} {...message} />
+            <MessageBox
+              key={index}
+              {...message}
+              onFeedbackSend={onFeedbackSend}
+            />
           ))}
           {loading && <MessageSkeleton />}
           <div ref={bottomRef} />

--- a/admin_app/src/app/playground/page.tsx
+++ b/admin_app/src/app/playground/page.tsx
@@ -15,6 +15,7 @@ import {
   FeedbackSentimentType,
   ResponseSummary,
   UserMessage,
+  ResponseMessage,
 } from "./components/PlaygroundComponents";
 import { Box } from "@mui/material";
 import { useAuth } from "@/utils/auth";
@@ -204,17 +205,25 @@ const Page = () => {
     }
   };
 
-  const onFeedbackSend = (
-    query_id: number,
+  const sendResponseFeedback = (
+    message: ResponseMessage,
     feedback_sentiment: FeedbackSentimentType,
-    feedback_secret_key: string,
   ) => {
     if (token) {
+      // Assuming message.json is a JSON string. Parse it if necessary.
+      const jsonResponse =
+        typeof message.json === "string"
+          ? JSON.parse(message.json)
+          : message.json;
+
+      const queryID = jsonResponse.query_id;
+      const feedbackSecretKey = jsonResponse.feedback_secret_key;
+
       apiCalls
         .postResponseFeedback(
-          query_id,
+          queryID,
           feedback_sentiment,
-          feedback_secret_key,
+          feedbackSecretKey,
           token,
         )
         .then((response) => {
@@ -272,8 +281,8 @@ const Page = () => {
           {messages.map((message, index) => (
             <MessageBox
               key={index}
-              {...message}
-              onFeedbackSend={onFeedbackSend}
+              message={message}
+              onFeedbackSend={sendResponseFeedback}
             />
           ))}
           {loading && <MessageSkeleton />}

--- a/admin_app/src/utils/api.ts
+++ b/admin_app/src/utils/api.ts
@@ -315,6 +315,7 @@ const getLLMResponse = async (search: string, token: string) => {
 };
 
 const postResponseFeedback = async (
+  query_id: number,
   feedback_sentiment: string,
   feedback_secret_key: string,
   token: string,
@@ -327,20 +328,18 @@ const postResponseFeedback = async (
       Authorization: `Bearer ${token}`,
     },
     body: JSON.stringify({
+      query_id: query_id,
       feedback_sentiment: feedback_sentiment,
       feedback_secret_key: feedback_secret_key,
     }),
-  })
-    .then((response) => {
-      return response.json().then((data) => {
-        const responseWithStatus = { status: response.status, ...data };
-        return responseWithStatus;
-      });
-    })
-    .catch((error) => {
-      console.error("Error:", error);
-      throw error;
-    });
+  }).then((response) => {
+    if (response.ok) {
+      let resp = response.json();
+      return resp;
+    } else {
+      throw new Error("Error sending response feedback");
+    }
+  });
 };
 
 const getQuestionStats = async (token: string) => {
@@ -457,6 +456,7 @@ export const apiCalls = {
   getGoogleLoginToken,
   getEmbeddingsSearch,
   getLLMResponse,
+  postResponseFeedback,
   getQuestionStats,
   getUrgencyDetection,
   createTag,

--- a/admin_app/src/utils/api.ts
+++ b/admin_app/src/utils/api.ts
@@ -314,6 +314,35 @@ const getLLMResponse = async (search: string, token: string) => {
     });
 };
 
+const postResponseFeedback = async (
+  feedback_sentiment: string,
+  feedback_secret_key: string,
+  token: string,
+) => {
+  const feedbackUrl = `${NEXT_PUBLIC_BACKEND_URL}/response-feedback`;
+  return fetch(feedbackUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      feedback_sentiment: feedback_sentiment,
+      feedback_secret_key: feedback_secret_key,
+    }),
+  })
+    .then((response) => {
+      return response.json().then((data) => {
+        const responseWithStatus = { status: response.status, ...data };
+        return responseWithStatus;
+      });
+    })
+    .catch((error) => {
+      console.error("Error:", error);
+      throw error;
+    });
+};
+
 const getQuestionStats = async (token: string) => {
   return fetch(`${NEXT_PUBLIC_BACKEND_URL}/dashboard/question_stats`, {
     method: "GET",


### PR DESCRIPTION
Reviewer: @sidravi1  
Estimate: 15 min

---

## Ticket

Fixes: https://idinsight.atlassian.net/browse/AAQ-577

## Description

### Goal

Add response-level feedback buttons on playground

### Changes

1. Thumbs up button to send positive feedback
2. Thumbs down button to send negative feedback

We don't have a way to remove feedback, so if a feedback button is pressed, it is permanently pressed! Can't unsend feedback.

<img width="631" alt="image" src="https://github.com/user-attachments/assets/525604d3-657e-4b3c-a1d7-797656dbffc6">


### Future Tasks (optional)

1. Clicking on thumbs button opens a small text field to type any qualitative text.
2. Content-level feedback
3. Maybe consider allowing to cancel feedback. (will need enpoints to do that)
4. OR, snack bar message saying "Positive/negative feedback already sent"?

## How has this been tested?

- tested using `npm run dev`

Test cases:
1. Asking sound question: feedback buttons should show up.
2. Clicking on feedback button adds to query-response-feedback table (check DB)
3. Clicking on the same feedback button doesn't do anything
4. Asking an invalid question (unsafe, gibberish, etc.): feedback buttons should NOT show up


## To-do before merge (optional)

## Checklist

Fill with `x` for completed. 

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts

