### PR TITLE
Hotfix for alembic migration issue

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,4 +60,5 @@ jobs:
             POSTGRES_PASSWORD=$POSTGRES_PASSWORD POSTGRES_DB=$POSTGRES_DB \
             ALIGN_SCORE_API=$ALIGN_SCORE_API
           python -m alembic upgrade head
-          python -m pytest -m "not rails" tests
+          python -m pytest -m "not rails and alembic" tests/api/test_alembic_migrations.py
+          python -m pytest -m "not rails and not alembic" tests

--- a/core_backend/Makefile
+++ b/core_backend/Makefile
@@ -6,9 +6,12 @@
 tests: setup-test-containers run-tests teardown-test-containers
 
 # Test runner
+# NB: `pytest-alembic` requires the DB engine to point an empty database. Thus, alembic
+# tests should be run first.
 run-tests:
 	@set -a && source ./tests/api/test.env && set +a && \
-	python -m pytest -rPQ -m "not rails" tests
+	python -m pytest -rPQ -m "not rails and alembic" tests/api/test_alembic_migrations.py && \
+	python -m pytest -rPQ -m "not rails and not alembic" tests
 
 ## Helper targets
 setup-test-containers: setup-test-db

--- a/core_backend/app/contents/models.py
+++ b/core_backend/app/contents/models.py
@@ -6,6 +6,7 @@ from sqlalchemy import (
     JSON,
     DateTime,
     ForeignKey,
+    Index,
     Integer,
     String,
     delete,
@@ -18,7 +19,12 @@ from ..models import Base, JSONDict
 from ..schemas import FeedbackSentiment, QuerySearchResult
 from ..tags.models import content_tags_table
 from ..utils import embedding
-from .config import PGVECTOR_VECTOR_SIZE
+from .config import (
+    PGVECTOR_DISTANCE,
+    PGVECTOR_EF_CONSTRUCTION,
+    PGVECTOR_M,
+    PGVECTOR_VECTOR_SIZE,
+)
 from .schemas import (
     ContentCreate,
     ContentUpdate,
@@ -31,6 +37,19 @@ class ContentDB(Base):
     """
 
     __tablename__ = "content"
+
+    __table_args__ = (
+        Index(
+            "content_idx",
+            "content_embedding",
+            postgresql_using="hnsw",
+            postgresql_with={
+                "M": {PGVECTOR_M},
+                "ef_construction": {PGVECTOR_EF_CONSTRUCTION},
+            },
+            postgresql_ops={"embedding": {PGVECTOR_DISTANCE}},
+        ),
+    )
 
     content_id: Mapped[int] = mapped_column(Integer, primary_key=True, nullable=False)
     user_id: Mapped[int] = mapped_column(

--- a/core_backend/migrations/env.py
+++ b/core_backend/migrations/env.py
@@ -17,8 +17,10 @@ config.set_main_option("sqlalchemy.url", connection_string)
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
+# See: https://pytest-alembic.readthedocs.io/en/latest/setup.html#caplog-issues for
+# more info on fileConfig for `pytest-alembic`.
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    fileConfig(config.config_file_name, disable_existing_loggers=True)
 
 # add your model's MetaData object here
 # for 'autogenerate' support
@@ -26,7 +28,7 @@ if config.config_file_name is not None:
 # target_metadata = mymodel.Base.metadata
 target_metadata = models.Base.metadata
 
-# other values from the config, defined by the needs of env.py,
+# other values from the config, defined by the needs of env.py,q
 # can be acquired:
 # my_important_option = config.get_main_option("my_important_option")
 # ... etc.
@@ -59,15 +61,22 @@ def run_migrations_offline() -> None:
 def run_migrations_online() -> None:
     """Run migrations in 'online' mode.
 
-    In this scenario we need to create an Engine
-    and associate a connection with the context.
+    In normal migration scenarios, we need to create an Engine and associate a
+    connection with the context.
 
+    For `pytest-alembic`, the connection is provided by `pytest-alembic` at runtime.
+    Thus, we create a check to see if `connectable` already exists. This allows the same
+    `env.py` to be used for both `pytest-alembic` and regular migrations.
     """
-    connectable = engine_from_config(
-        config.get_section(config.config_ini_section, {}),
-        prefix="sqlalchemy.",
-        poolclass=pool.NullPool,
-    )
+
+    connectable = context.config.attributes.get("connection", None)
+
+    if connectable is None:
+        connectable = engine_from_config(
+            config.get_section(config.config_ini_section, {}),
+            prefix="sqlalchemy.",
+            poolclass=pool.NullPool,
+        )
 
     with connectable.connect() as connection:
         context.configure(connection=connection, target_metadata=target_metadata)

--- a/core_backend/tests/api/conftest.py
+++ b/core_backend/tests/api/conftest.py
@@ -5,7 +5,9 @@ from typing import Any, AsyncGenerator, Dict, Generator, List, Optional, Tuple
 import numpy as np
 import pytest
 from fastapi.testclient import TestClient
+from pytest_alembic.config import Config
 from sqlalchemy import delete
+from sqlalchemy.engine import Engine, create_engine
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 from sqlalchemy.orm import Session
 
@@ -19,6 +21,7 @@ from core_backend.app.config import (
 from core_backend.app.contents.config import PGVECTOR_VECTOR_SIZE
 from core_backend.app.contents.models import ContentDB
 from core_backend.app.database import (
+    SYNC_DB_API,
     get_connection_url,
     get_session_context_manager,
 )
@@ -337,3 +340,30 @@ def fullaccess_token_user2() -> str:
     Returns a token with full access
     """
     return create_access_token(TEST_USERNAME_2)
+
+
+@pytest.fixture(scope="session")
+def alembic_config() -> Config:
+    """`alembic_config` is the primary point of entry for configurable options for the
+    alembic runner for `pytest-alembic`.
+
+    :returns:
+        Config: A configuration object used by `pytest-alembic`.
+    """
+
+    return Config({"file": "alembic.ini"})
+
+
+@pytest.fixture(scope="function")
+def alembic_engine() -> Engine:
+    """`alembic_engine` is where you specify the engine with which the alembic_runner
+    should execute your tests.
+
+    NB: The engine should point to a database that must be empty. It is out of scope
+    for `pytest-alembic` to manage the database state.
+
+    :returns:
+        A SQLAlchemy engine object.
+    """
+
+    return create_engine(get_connection_url(db_api=SYNC_DB_API))

--- a/core_backend/tests/api/test_alembic_migrations.py
+++ b/core_backend/tests/api/test_alembic_migrations.py
@@ -1,0 +1,63 @@
+"""This module tests alembic migrations using `pytest-alembic`.
+
+`pytest-alembic` defines two database fixtures, `alembic_config` and `alembic_engine`,
+which are used to test the migrations. These fixtures are defined in the local
+conftest.py.
+
+NB: The `alembic_runner` fixture is used to skip alembic tests.
+"""
+
+from typing import Any, Callable
+
+import alembic
+from pytest_alembic import create_alembic_fixture, tests
+
+migration_history = create_alembic_fixture()
+
+
+def test_single_head_revision(
+    alembic_runner: Callable[[dict[str, Any] | alembic.config.Config | None], Callable],
+    migration_history: tests.MigrationHistory,
+) -> None:
+    """Assert that there only exists one head revision."""
+
+    tests.test_single_head_revision(migration_history)
+
+
+def test_upgrade(
+    alembic_runner: Callable[[dict[str, Any] | alembic.config.Config | None], Callable],
+    migration_history: tests.MigrationHistory,
+) -> None:
+    """Assert that the revision history can be run through from base to head."""
+
+    tests.test_upgrade(migration_history)
+
+
+def test_model_definitions_match_ddl(
+    alembic_runner: Callable[[dict[str, Any] | alembic.config.Config | None], Callable],
+    migration_history: tests.MigrationHistory,
+) -> None:
+    """Assert that the state of the migrations matches the state of the models
+    describing the DDL.
+
+    In general, the set of migrations in the history should coalesce into DDL which is
+    described by the current set of models. Therefore, a call to revision --autogenerate
+    should always generate an empty migration (e.g. find no difference between your
+    database (i.e. migrations history) and your models).
+    """
+
+    tests.test_model_definitions_match_ddl(migration_history)
+
+
+def test_up_down_consistency(
+    alembic_runner: Callable[[dict[str, Any] | alembic.config.Config | None], Callable],
+    migration_history: tests.MigrationHistory,
+) -> None:
+    """Assert that all downgrades succeed.
+
+    While downgrading may not be lossless operation data-wise, there’s a theory of
+    database migrations that says that the revisions in existence for a database should
+    be able to go from an entirely blank schema to the finished product, and back again.
+    """
+
+    tests.test_up_down_consistency(migration_history)

--- a/core_backend/tests/api/test_alembic_migrations.py
+++ b/core_backend/tests/api/test_alembic_migrations.py
@@ -17,7 +17,7 @@ migration_history = create_alembic_fixture()
 
 def test_single_head_revision(
     alembic_runner: Callable[[dict[str, Any] | alembic.config.Config | None], Callable],
-    migration_history: tests.MigrationHistory,
+    migration_history: Callable,
 ) -> None:
     """Assert that there only exists one head revision.
 
@@ -31,7 +31,7 @@ def test_single_head_revision(
 
 def test_upgrade(
     alembic_runner: Callable[[dict[str, Any] | alembic.config.Config | None], Callable],
-    migration_history: tests.MigrationHistory,
+    migration_history: Callable,
 ) -> None:
     """Assert that the revision history can be run through from base to head.
 
@@ -45,7 +45,7 @@ def test_upgrade(
 
 def test_model_definitions_match_ddl(
     alembic_runner: Callable[[dict[str, Any] | alembic.config.Config | None], Callable],
-    migration_history: tests.MigrationHistory,
+    migration_history: Callable,
 ) -> None:
     """Assert that the state of the migrations matches the state of the models
     describing the DDL.
@@ -65,7 +65,7 @@ def test_model_definitions_match_ddl(
 
 def test_up_down_consistency(
     alembic_runner: Callable[[dict[str, Any] | alembic.config.Config | None], Callable],
-    migration_history: tests.MigrationHistory,
+    migration_history: Callable,
 ) -> None:
     """Assert that all downgrades succeed.
 

--- a/core_backend/tests/api/test_alembic_migrations.py
+++ b/core_backend/tests/api/test_alembic_migrations.py
@@ -19,7 +19,12 @@ def test_single_head_revision(
     alembic_runner: Callable[[dict[str, Any] | alembic.config.Config | None], Callable],
     migration_history: tests.MigrationHistory,
 ) -> None:
-    """Assert that there only exists one head revision."""
+    """Assert that there only exists one head revision.
+
+    :param alembic_runner: A fixture which provides a callable to run alembic
+        migrations.
+    :param migration_history: A fixture which provides a history of alembic migrations.
+    """
 
     tests.test_single_head_revision(migration_history)
 
@@ -28,7 +33,12 @@ def test_upgrade(
     alembic_runner: Callable[[dict[str, Any] | alembic.config.Config | None], Callable],
     migration_history: tests.MigrationHistory,
 ) -> None:
-    """Assert that the revision history can be run through from base to head."""
+    """Assert that the revision history can be run through from base to head.
+
+    :param alembic_runner: A fixture which provides a callable to run alembic
+        migrations.
+    :param migration_history: A fixture which provides a history of alembic migrations.
+    """
 
     tests.test_upgrade(migration_history)
 
@@ -44,6 +54,10 @@ def test_model_definitions_match_ddl(
     described by the current set of models. Therefore, a call to revision --autogenerate
     should always generate an empty migration (e.g. find no difference between your
     database (i.e. migrations history) and your models).
+
+    :param alembic_runner: A fixture which provides a callable to run alembic
+        migrations.
+    :param migration_history: A fixture which provides a history of alembic migrations.
     """
 
     tests.test_model_definitions_match_ddl(migration_history)
@@ -58,6 +72,10 @@ def test_up_down_consistency(
     While downgrading may not be lossless operation data-wise, there’s a theory of
     database migrations that says that the revisions in existence for a database should
     be able to go from an entirely blank schema to the finished product, and back again.
+
+    :param alembic_runner: A fixture which provides a callable to run alembic
+        migrations.
+    :param migration_history: A fixture which provides a history of alembic migrations.
     """
 
     tests.test_up_down_consistency(migration_history)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@ ruff-lsp==0.0.39
 mypy==1.8.0
 pytest==7.4.2
 pytest-asyncio==0.23.2
+pytest-alembic==0.11.0
 pytest-xdist==3.5.0
 httpx==0.25.0
 trio==0.22.2


### PR DESCRIPTION
Reviewer: @sidravi1 
Estimate: ~20 min

---

## Ticket

Fixes: N/A

## Description

### Goal

A [previous alembic migration](https://github.com/IDinsight/aaq-core/blob/main/core_backend/migrations/versions/2024_02_18_f269c75dbf69_create_content_table.py) created the `content_idx` index. However, the `ContentDB` model definition was not updated. This caused a mismatch between the state of alembic migrations and the state of the `ContentDB` model definition.

### Changes

1. Updated the `ContentDB` model definition to include the existing `content_idx` index.

### Future Tasks (optional)

## How has this been tested?

1. The updated `ContentDB` model was tested using `pytest-alembic`. 
2. In addition, a manual call to `alembic revision --autogenerate ...` was executed to check that the autogenerated revision file is empty.

## To-do before merge (optional)

1. Since this PR also relies on `pytest-alembic`, I can discuss what this library does exactly. Upcoming PRs will include unit tests that make use of this library.

## Checklist

Fill with `x` for completed. 

- [X] My code follows the style guidelines of this project
- [X] I have reviewed my own code to ensure good quality
- [X] I have tested the functionality of my code to ensure it works as intended
- [X] I have resolved merge conflicts

(Delete any items below that are not relevant)
- [X] I have updated the automated tests
- [X] I have updated the requirements
- [X] I have updated the CI/CD scripts in `.github/workflows/`