### PR TITLE
Auto add PYTHONPATH for running scripts.

### DIFF
--- a/scripts/add_dummy_data_to_db.py
+++ b/scripts/add_dummy_data_to_db.py
@@ -1,6 +1,6 @@
 # This script is useful if you want to test the dashboard with dummy data.
-# Run it using the following command:
-#   > cd ~/aaq-core && python scripts/add_dummy_data_to_db.py
+# Navigate to the root directory of the project and run the following command:
+#   > python scripts/add_dummy_data_to_db.py
 
 import os
 import random

--- a/scripts/add_dummy_data_to_db.py
+++ b/scripts/add_dummy_data_to_db.py
@@ -6,6 +6,7 @@ import os
 import random
 import sys
 from datetime import datetime, timedelta
+from pathlib import Path
 
 import numpy as np
 from sqlalchemy.orm import Session
@@ -13,7 +14,7 @@ from sqlalchemy.orm import Session
 # Append the framework path. NB: This is required if this script is invoked from the
 # command line. However, it is not necessary if it is imported from a pip install.
 if __name__ == "__main__":
-    PACKAGE_PATH = os.path.abspath(__file__)
+    PACKAGE_PATH = str(Path(__file__).resolve())
     PACKAGE_PATH_SPLIT = PACKAGE_PATH.split(os.path.join("scripts"))
     PACKAGE_PATH = PACKAGE_PATH_SPLIT[0]
     if PACKAGE_PATH not in sys.path:

--- a/scripts/add_dummy_data_to_db.py
+++ b/scripts/add_dummy_data_to_db.py
@@ -1,13 +1,25 @@
 # This script is useful if you want to test the dashboard with dummy data.
 # Run it using the following command:
-#    > PYTHON_PATH="../../../" python add_dummy_data_to_db.py
+#   > cd ~/aaq-core && python scripts/add_dummy_data_to_db.py
 
 import os
 import random
+import sys
 from datetime import datetime, timedelta
 
 import numpy as np
 from sqlalchemy.orm import Session
+
+# Append the framework path. NB: This is required if this script is invoked from the
+# command line. However, it is not necessary if it is imported from a pip install.
+if __name__ == "__main__":
+    PACKAGE_PATH = os.path.abspath(__file__)
+    PACKAGE_PATH_SPLIT = PACKAGE_PATH.split(os.path.join("scripts"))
+    PACKAGE_PATH = PACKAGE_PATH_SPLIT[0]
+    if PACKAGE_PATH not in sys.path:
+        print(f"Appending '{PACKAGE_PATH}' to system path.")
+        sys.path.append(PACKAGE_PATH)
+
 
 from core_backend.app.contents.config import PGVECTOR_VECTOR_SIZE
 from core_backend.app.contents.models import ContentDB


### PR DESCRIPTION
Reviewer: @sidravi1 
Estimate: ~2 minutes

---

## Ticket

Fixes: N/A

## Description

### Goal

Automatically append the framework path for scripts so that the user does not have to manually export `PYTHONPATH` in terminal.

### Changes

1. Added logic for automatically appending `PYTHONPATH` and updated instructions on how to execute scripts.

### Future Tasks (optional)

## How has this been tested?

1. Ran `add_dummy_data_to_db.py` locally in fresh terminal without having to manually export `PYTHONPATH`.

## To-do before merge (optional)

## Checklist

Fill with `x` for completed. 

- [X] My code follows the style guidelines of this project
- [X] I have reviewed my own code to ensure good quality
- [X] I have tested the functionality of my code to ensure it works as intended
- [X] I have resolved merge conflicts

(Delete any items below that are not relevant)
- [X] I have updated the scripts in `scripts/`