### PR TITLE
Fixed Makefile docker command.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ setup-llm-proxy:
 		--name litellm-proxy \
 		--rm \
 		-v "$(CURDIR)/deployment/docker-compose/litellm_proxy_config.yaml":/app/config.yaml \
-		-v "$(CURDIR)/deployment/docker-compose/.gcp_credentials.json":/app/credentials.json \
+		-v "$(CURDIR)/deployment/docker-compose/.gcp-credentials.json":/app/credentials.json \
 		-e OPENAI_API_KEY=$(OPENAI_API_KEY) \
 		-e EMBEDDINGS_API_KEY=$(EMBEDDINGS_API_KEY) \
 		-e EMBEDDINGS_ENDPOINT=$(EMBEDDINGS_ENDPOINT) \


### PR DESCRIPTION
Reviewer: @suzinyou 
Estimate: 30 seconds

---

## Ticket

Fixes: N/A

## Description

### Goal

Fixed make target typo that resulted in creating a `.gcp-credentials.json` folder in `deploymnet/docker-compose`.

### Changes

1. Changed make target typo from underscore to dash character.

### Future Tasks (optional)

## How has this been tested?

1. Ran `make setup-dev` locally and verified that no extra directories were created in `deployment/docker-compose`.

## To-do before merge (optional)

## Checklist

Fill with `x` for completed. 

- [X] My code follows the style guidelines of this project
- [X] I have reviewed my own code to ensure good quality
- [X] I have tested the functionality of my code to ensure it works as intended
- [X] I have resolved merge conflicts